### PR TITLE
Quick fix for map focus border

### DIFF
--- a/server/views/map-reservoirs.html
+++ b/server/views/map-reservoirs.html
@@ -17,7 +17,7 @@
 
 {% block main %}
 <div class="map-container">
-  <div id="map" tabindex="0" aria-label="Use your arrows to navigate the map. To zoom in and out cycle back to the zoom buttons."></div>
+  <div id="map" aria-label="Use your arrows to navigate the map. To zoom in and out cycle back to the zoom buttons."></div>
   {% include 'partials/map-page/map-controls.html' %}
   <!-- Key -->
   <!-- map-key inline styling required for ability to click off key on devices -->

--- a/server/views/map-surface-water.html
+++ b/server/views/map-surface-water.html
@@ -17,7 +17,7 @@
 
 {% block main %}
 <div class="map-container">
-  <div id="map" tabindex="0" aria-label="Use your arrows to navigate the map. To zoom in and out cycle back to the zoom buttons."></div>
+  <div id="map" aria-label="Use your arrows to navigate the map. To zoom in and out cycle back to the zoom buttons."></div>
   {% include 'partials/map-page/map-controls.html' %}
   <!-- Key -->
   <!-- map-key inline styling required for ability to click off key on devices -->


### PR DESCRIPTION
Tab index needs to be removed on surface water and reservoir pages.