### PR TITLE
Propagate data service 500 error for errors in query results

### DIFF
--- a/server/routes/__tests__/risk.spec.js
+++ b/server/routes/__tests__/risk.spec.js
@@ -124,7 +124,9 @@ describe('Risk page test', () => {
       floodWarningArea: [],
       leadLocalFloodAuthority: 'Cheshire West and Chester',
       reservoirRisk: null,
-      riverAndSeaRisk: 'Error',
+      riverAndSeaRisk: {
+        error: 'Internal Error'
+      },
       surfaceWaterRisk: 'Very Low',
       extraInfo: null
     })
@@ -140,7 +142,9 @@ describe('Risk page test', () => {
       leadLocalFloodAuthority: 'Cheshire West and Chester',
       reservoirRisk: null,
       riverAndSeaRisk: null,
-      surfaceWaterRisk: 'Error',
+      surfaceWaterRisk: {
+        error: 'Internal Error'
+      },
       extraInfo: null
     })
     const response = await server.inject(defaultOptions)
@@ -153,7 +157,9 @@ describe('Risk page test', () => {
       floodAlertArea: [],
       floodWarningArea: [],
       leadLocalFloodAuthority: 'Cheshire West and Chester',
-      reservoirDryRisk: 'Error',
+      reservoirDryRisk: {
+        error: 'Internal Error'
+      },
       riverAndSeaRisk: { probabilityForBand: 'Low' },
       surfaceWaterRisk: null,
       extraInfo: null
@@ -167,7 +173,9 @@ describe('Risk page test', () => {
       floodAlertArea: [],
       floodWarningArea: [],
       leadLocalFloodAuthority: 'Cheshire West and Chester',
-      reservoirWetRisk: 'Error',
+      reservoirWetRisk: {
+        error: 'Internal Error'
+      },
       riverAndSeaRisk: { probabilityForBand: 'Low' },
       surfaceWaterRisk: null,
       extraInfo: null
@@ -181,7 +189,9 @@ describe('Risk page test', () => {
       isGroundwaterArea: false,
       floodAlertArea: [],
       floodWarningArea: [],
-      leadLocalFloodAuthority: 'Error',
+      leadLocalFloodAuthority: {
+        error: 'Internal Error'
+      },
       reservoirRisk: null,
       riverAndSeaRisk: { probabilityForBand: 'Low' },
       surfaceWaterRisk: null,

--- a/server/routes/risk.js
+++ b/server/routes/risk.js
@@ -22,13 +22,14 @@ module.exports = {
 
       try {
         const risk = await request.server.methods.riskService(x, y, radius)
+
         // FLO-1139 If query 1 to 6 errors then throw default error page
-        const hasError = risk.riverAndSeaRisk === 'Error' ||
-          risk.surfaceWaterRisk === 'Error' ||
-          risk.reservoirDryRisk === 'Error' ||
-          risk.reservoirWetRisk === 'Error' ||
-          risk.leadLocalFloodAuthority === 'Error' ||
-          risk.extraInfo === 'Error'
+        const hasError = risk.riverAndSeaRisk?.error ||
+          risk.surfaceWaterRisk?.error ||
+          risk.reservoirDryRisk?.error ||
+          risk.reservoirWetRisk?.error ||
+          risk.leadLocalFloodAuthority?.error ||
+          risk.extraInfo?.error
 
         if (hasError) {
           return boom.badRequest(errors.spatialQuery.message, {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/LTFRI-1449

Create a way to handle the error so it provides logging for failures getting risk data from the service.