### PR TITLE
remove full stops on surface water depth page

### DIFF
--- a/server/views/partials/floodRatings.html
+++ b/server/views/partials/floodRatings.html
@@ -8,21 +8,21 @@
     <p class="govuk-body govuk-!-margin-top-4 govuk-!-margin-bottom-0 govuk-!-padding-bottom-4">
       <strong class="govuk-tag govuk-tag--High">High</strong>
     </p>
-    <p class="govuk-body">More than 3.3% chance of a flood each year.</p>
+    <p class="govuk-body">More than 3.3% chance of a flood each year</p>
     <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
     <p class="govuk-body govuk-!-margin-top-4 govuk-!-margin-bottom-0 govuk-!-padding-bottom-4">
       <strong class="govuk-tag govuk-tag--Medium">Medium</strong>
     </p>
-    <p class="govuk-body">Between 1% and 3.3% chance of a flood each year.</p>
+    <p class="govuk-body">Between 1% and 3.3% chance of a flood each year</p>
     <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
     <p class="govuk-body govuk-!-margin-top-4 govuk-!-margin-bottom-0 govuk-!-padding-bottom-4">
       <strong class="govuk-tag govuk-tag--Low">Low</strong>
     </p>
-    <p class="govuk-body">Between 0.1% and 1% chance of a flood each year.</p>
+    <p class="govuk-body">Between 0.1% and 1% chance of a flood each year</p>
     <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
     <p class="govuk-body govuk-!-margin-top-4 govuk-!-margin-bottom-0 govuk-!-padding-bottom-4">
       <strong class="govuk-tag govuk-tag--Very-Low">Very low</strong>
     </p>
-    <p class="govuk-body">Less than 0.1% chance of a flood each year.</p>
+    <p class="govuk-body">Less than 0.1% chance of a flood each year</p>
   </div>
 </details>


### PR DESCRIPTION
https://eaflood.atlassian.net/jira/software/c/projects/LTFRI/boards/589?selectedIssue=LTFRI-1523

This change fixes the "what the flood risk ratings mean" accordion as the full stops need to be removed.
