### PR TITLE
Quick fix for missing RS desc on tech map

### DIFF
--- a/server/views/map.html
+++ b/server/views/map.html
@@ -290,6 +290,7 @@
                             </svg>
                           </span>
                           <span id="risk-severity" class="risk-severity-text">High chance</span>
+                          <span class="risk-context">More than 3.3% chance each year</span>
                         </span>
             
                         <span
@@ -301,6 +302,7 @@
                             </svg>
                           </span>
                           <span class="risk-severity-text">Medium chance</span>
+                          <span class="risk-context">Between 1% and 3.3% chance each year</span>
                         </span>
             
                         <span
@@ -312,6 +314,7 @@
                             </svg>
                           </span>
                           <span class="risk-severity-text">Low chance</span>
+                          <span class="risk-context">Between 0.1% and 1% chance each year</span>
                         </span>
                         
                         <span
@@ -323,6 +326,7 @@
                             </svg>
                           </span>
                           <span class="risk-severity-text">Very low chance</span>
+                          <span class="risk-context">Less than 0.1% chance each year</span>
                         </span>
                       </div>
                     </label>
@@ -402,6 +406,7 @@
                             </svg>
                           </span>
                           <span id="risk-severity" class="risk-severity-text">High chance</span>
+                          <span class="risk-context">More than 3.3% chance each year</span>
                         </span>
             
                         <span
@@ -413,6 +418,7 @@
                             </svg>
                           </span>
                           <span class="risk-severity-text">Medium chance</span>
+                          <span class="risk-context">Between 1% and 3.3% chance each year</span>
                         </span>
             
                         <span
@@ -424,6 +430,7 @@
                             </svg>
                           </span>
                           <span class="risk-severity-text">Low chance</span>
+                          <span class="risk-context">Between 0.1% and 1% chance each year</span>
                         </span>
                         
                         <span
@@ -435,6 +442,7 @@
                             </svg>
                           </span>
                           <span class="risk-severity-text">Very low chance</span>
+                          <span class="risk-context">Less than 0.1% chance each year</span>
                         </span>
   
                         <span


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/LTFRI-1540

The RS tech map options are not showing the % information for extent.