### PR TITLE
add 'no data available' option on Rivers and Sea depth legend

### DIFF
--- a/server/views/map.html
+++ b/server/views/map.html
@@ -545,6 +545,16 @@
                           <span class="risk-severity-text">Very low chance</span>
                           <span class="risk-context">Less than 0.1% chance each year</span>
                         </span>
+                        <span
+                        class="defra-map-key__symbol-container-v3 defra-map-key__symbol-container--multi rs-extent-container"
+                        id="rs-extent-no-data">
+                        <span class="defra-map-key__symbol">
+                          <svg class="risk-square-svg" aria-hidden="true" focusable="false" viewBox="0 0 36 36">
+                            <rect class="no-data-symbol risk-colour-square" x="5" y="5"></rect>
+                          </svg>
+                        </span>
+                        <span class="risk-severity-text">No data available</span>
+                      </span>
                       </div>
                     </label>
                   </div>


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/LTFRI-1580

add the no data available option on the legend for depth on the technical map only.