### PR TITLE
change R&S extent heading in technical map

### DIFF
--- a/server/views/map.html
+++ b/server/views/map.html
@@ -300,7 +300,7 @@
                       value="{{maps.categories[0].maps[0].ref}}"
                       title="Extent of flooding from rivers and sea" name="measurements" type="radio">
                     <label class="govuk-label govuk-radios__label" for="rs-extent-radio">
-                      <span class="rivers-and-sea-bulletpoint__heading" id="rivers-and-sea-extent__heading">Flood area (extent)</span>
+                      <span class="rivers-and-sea-bulletpoint__heading" id="rivers-and-sea-extent__heading">Extent</span>
             
                       <div id="rs-extent-desc-container" class="extent-desc-container desc-container">
                         <span
@@ -426,7 +426,7 @@
                       value="{{maps.categories[0].maps[1].ref}}"
                       title="Extent of flooding from rivers and sea (2036-2069)" name="measurements" type="radio">
                     <label class="govuk-label govuk-radios__label" for="rs-extent-radio-cc">
-                      <span class="rivers-and-sea-bulletpoint__heading" id="rivers-and-sea-extent__heading">Flood area (extent)</span>
+                      <span class="rivers-and-sea-bulletpoint__heading" id="rivers-and-sea-extent__heading">Extent</span>
                       <div id="rs-extent-desc-container-cc" class="extent-desc-container-cc desc-container hide">
                         <span
                           class="defra-map-key__symbol-container-v3 defra-map-key__symbol-container--multi rs-extent-container"


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/LTFRI-1586

In the technical map, a bug was found where the Rivers and sea extent headings differed from the surface water ones.