### PR TITLE
Zoom button appears on the wrong side

### DIFF
--- a/client/sass/_map-controls.scss
+++ b/client/sass/_map-controls.scss
@@ -408,6 +408,7 @@ $gov-font: "HelveticaNeue", "Helvetica Neue", "Arial", "Helvetica", sans-serif;
 
   .esri-zoom {
     margin-bottom: 25px;
+    margin-right: 5px;
   }
   
   .esri-zoom.with-scenario-bar {


### PR DESCRIPTION
https://eaflood.atlassian.net/jira/software/c/projects/LTFRI/boards/589?selectedIssue=LTFRI-1500

This change fixes the alignment of the zoom buttons to match the scenario bar.