### PR TITLE
remove zoom buttons on the mobile version (N2 env)

### DIFF
--- a/client/sass/_map-controls.scss
+++ b/client/sass/_map-controls.scss
@@ -410,7 +410,7 @@ $gov-font: "HelveticaNeue", "Helvetica Neue", "Arial", "Helvetica", sans-serif;
     margin-bottom: 25px;
     margin-right: 5px;
     
-    @media (max-width: 768px) {
+    @media screen and (max-width: $tablet-width) {
       display: none;
     }
   }

--- a/client/sass/_map-controls.scss
+++ b/client/sass/_map-controls.scss
@@ -409,6 +409,10 @@ $gov-font: "HelveticaNeue", "Helvetica Neue", "Arial", "Helvetica", sans-serif;
   .esri-zoom {
     margin-bottom: 25px;
     margin-right: 5px;
+    
+    @media (max-width: 768px) {
+      display: none;
+    }
   }
   
   .esri-zoom.with-scenario-bar {


### PR DESCRIPTION
https://eaflood.atlassian.net/jira/software/c/projects/LTFRI/boards/589?selectedIssue=LTFRI-1602

This change removes the zoom button from the mobile version of the map as it is not currently required.