### PR TITLE
Amend colour of very low tag on more about R&S page

### DIFF
--- a/client/sass/_rivers-and-sea.scss
+++ b/client/sass/_rivers-and-sea.scss
@@ -1,20 +1,20 @@
-.govuk-tag--High {
+.govuk-tag--high {
   color: #2a0b06;
   background-color: #f4cdc6;
 }
-.govuk-tag--Medium {
+.govuk-tag--medium {
   background-color: #FFDEBF;
   color: #6e3619;
 }
-.govuk-tag--Low {
+.govuk-tag--low {
   color: #594d00;
   background-color: #fff7bf;
 }
-.govuk-tag--Very-low {
+.govuk-tag--very-low {
   color: #0c2d4a;
   background-color: #CCE2D8;
 }
-.govuk-tag--No-Data {
+.govuk-tag--no-Data {
   color: #0b0c0c;
   background-color: #b0b3b580;
 }

--- a/server/models/risk-view.js
+++ b/server/models/risk-view.js
@@ -29,16 +29,16 @@ function riskViewModel (risk, address, backLinkUri) {
   const reservoirWetRisk = !!(risk.reservoirWetRisk?.length)
   const reservoirRisk = reservoirDryRisk || reservoirWetRisk
 
-  this.riverAndSeaRisk = riverAndSeaRisk.toLowerCase()
-  this.riverAndSeaRiskCC = riverAndSeaRiskCC.toLowerCase()
-  this.surfaceWaterRisk = surfaceWaterRisk.toLowerCase()
-  this.surfaceWaterRiskCC = surfaceWaterRiskCC.toLowerCase()
-  this.riverAndSeaClassName = riverAndSeaRisk.toLowerCase().replace(' ', '-')
-  this.surfaceWaterClassName = surfaceWaterRisk.toLowerCase().replace(' ', '-')
-  this.riversSeaRiskStyle = riverAndSeaRisk.replace(/ /g, '-')
-  this.surfaceWaterStyle = surfaceWaterRisk.replace(/ /g, '-')
-  this.riversSeaRiskCCStyle = riverAndSeaRiskCC.replace(/ /g, '-')
-  this.surfaceWaterCCStyle = surfaceWaterRiskCC.replace(/ /g, '-')
+  // The below functions are added as some of the incoming data varies in whether the first
+  // letter is capitalised or not. This ensures that the first words letter is always capitalised.
+  this.riverAndSeaRisk = riverAndSeaRisk.charAt(0).toUpperCase() + riverAndSeaRisk.slice(1).toLowerCase()
+  this.riverAndSeaRiskCC = riverAndSeaRiskCC.charAt(0).toUpperCase() + riverAndSeaRiskCC.slice(1).toLowerCase()
+  this.surfaceWaterRisk = surfaceWaterRisk.charAt(0).toUpperCase() + surfaceWaterRisk.slice(1).toLowerCase()
+  this.surfaceWaterRiskCC = surfaceWaterRiskCC.charAt(0).toUpperCase() + surfaceWaterRiskCC.slice(1).toLowerCase()
+  this.riversSeaRiskStyle = riverAndSeaRisk.toLowerCase().replace(/ /g, '-')
+  this.surfaceWaterStyle = surfaceWaterRisk.toLowerCase().replace(/ /g, '-')
+  this.riversSeaRiskCCStyle = riverAndSeaRiskCC.toLowerCase().replace(/ /g, '-')
+  this.surfaceWaterCCStyle = surfaceWaterRiskCC.toLowerCase().replace(/ /g, '-')
   this.reservoirRisk = reservoirRisk
   this.backLink = backLinkUri
 

--- a/server/views/partials/rivers-sea.html
+++ b/server/views/partials/rivers-sea.html
@@ -14,8 +14,8 @@
       <div class="govuk-summary-list__row">
         <h3 class="govuk-heading-s">Yearly chance of flooding</h3>
         <div class="risk-label-group-2 govuk-!-margin-top-4 govuk-!-margin-bottom-3">
-          {% if riverAndSeaRisk === "very low" %}
-          <strong class="govuk-tag govuk-tag--Very-low label-mod label-border">
+          {% if riverAndSeaRisk === "Very low" %}
+          <strong class="govuk-tag govuk-tag--{{ riversSeaRiskStyle }} label-mod label-border">
             Very low<span class="govuk-visually-hidden"> within a scale of very low, low, medium and high.</span>
           </strong>
           {% else %}
@@ -24,8 +24,8 @@
           </strong>
           {% endif %}
 
-          {% if riverAndSeaRisk === "low" %}
-          <strong class="govuk-tag govuk-tag--Low label-mod label-border">
+          {% if riverAndSeaRisk === "Low" %}
+          <strong class="govuk-tag govuk-tag--{{ riversSeaRiskStyle }} label-mod label-border">
             Low<span class="govuk-visually-hidden"> within a scale of very low, low, medium and high.</span>
           </strong>
           {% else %}
@@ -34,8 +34,8 @@
           </strong>
           {% endif %}
 
-          {% if riverAndSeaRisk === "medium" %}
-          <strong class="govuk-tag govuk-tag--Medium label-mod label-border">
+          {% if riverAndSeaRisk === "Medium" %}
+          <strong class="govuk-tag govuk-tag--{{ riversSeaRiskStyle }} label-mod label-border">
             Medium<span class="govuk-visually-hidden"> within a scale of very low, low, medium and high.</span>
           </strong>
           {% else %}
@@ -44,8 +44,8 @@
           </strong>
           {% endif %}
 
-          {% if riverAndSeaRisk === "high" %}
-          <strong class="govuk-tag govuk-tag--High label-mod label-border">
+          {% if riverAndSeaRisk === "High" %}
+          <strong class="govuk-tag govuk-tag--{{ riversSeaRiskStyle }} label-mod label-border">
             High<span class="govuk-visually-hidden"> within a scale of very low, low, medium and high.</span>
           </strong>
           {% else %}
@@ -56,7 +56,7 @@
         </div>
         <h3 class="govuk-heading-s govuk-!-padding-top-6 govuk-!-margin-bottom-0">Yearly chance of flooding between 2036 and 2069</h3>
         <div class="risk-label-group-2 govuk-!-margin-top-4 govuk-!-margin-bottom-3">
-          {% if riverAndSeaRiskCC === "unavailable" %}
+          {% if riverAndSeaRiskCC === "Unavailable" %}
           <strong class="govuk-tag govuk-tag--No-Data label-mod label-border">
             No data available<span class="govuk-visually-hidden"> within a scale of very low, low, medium and high.</span>
           </strong>
@@ -64,8 +64,8 @@
             when it becomes available.  
           </p>
           {% else %}
-            {% if riverAndSeaRiskCC === "very low" %}
-            <strong class="govuk-tag govuk-tag--Very-low label-mod label-border">
+            {% if riverAndSeaRiskCC === "Very low" %}
+            <strong class="govuk-tag govuk-tag--{{ riversSeaRiskCCStyle }} label-mod label-border">
               Very low<span class="govuk-visually-hidden"> within a scale of very low, low, medium and high.</span>
             </strong>
             {% else %}
@@ -74,8 +74,8 @@
             </strong>
             {% endif %}
 
-            {% if riverAndSeaRiskCC === "low" %}
-            <strong class="govuk-tag govuk-tag--Low label-mod label-border">
+            {% if riverAndSeaRiskCC === "Low" %}
+            <strong class="govuk-tag govuk-tag--{{ riversSeaRiskCCStyle }} label-mod label-border">
               Low<span class="govuk-visually-hidden"> within a scale of very low, low, medium and high.</span>
             </strong>
             {% else %}
@@ -84,8 +84,8 @@
             </strong>
             {% endif %}
 
-            {% if riverAndSeaRiskCC === "medium" %}
-            <strong class="govuk-tag govuk-tag--Medium label-mod label-border">
+            {% if riverAndSeaRiskCC === "Medium" %}
+            <strong class="govuk-tag govuk-tag--{{ riversSeaRiskCCStyle }} label-mod label-border">
               Medium<span class="govuk-visually-hidden"> within a scale of very low, low, medium and high.</span>
             </strong>
             {% else %}
@@ -94,8 +94,8 @@
             </strong>
             {% endif %}
 
-            {% if riverAndSeaRiskCC === "high" %}
-            <strong class="govuk-tag govuk-tag--High label-mod label-border">
+            {% if riverAndSeaRiskCC === "High" %}
+            <strong class="govuk-tag govuk-tag--{{ riversSeaRiskCCStyle }} label-mod label-border">
               High<span class="govuk-visually-hidden"> within a scale of very low, low, medium and high.</span>
             </strong>
             {% else %}

--- a/server/views/partials/surface-water.html
+++ b/server/views/partials/surface-water.html
@@ -14,8 +14,8 @@
       <div class="govuk-summary-list__row">
         <h3 class="govuk-heading-s">Yearly chance of flooding</h3>
         <div class="risk-label-group-2 govuk-!-margin-top-4 govuk-!-margin-bottom-3">
-          {% if surfaceWaterRisk === "very low" %}
-          <strong class="govuk-tag govuk-tag--Very-low label-mod label-border">
+          {% if surfaceWaterRisk === "Very low" %}
+          <strong class="govuk-tag govuk-tag--{{ surfaceWaterStyle }} label-mod label-border">
             Very low<span class="govuk-visually-hidden"> within a scale of very low, low, medium and high.</span>
           </strong>
           {% else %}
@@ -24,8 +24,8 @@
           </strong>
           {% endif %}
 
-          {% if surfaceWaterRisk === "low" %}
-          <strong class="govuk-tag govuk-tag--Low label-mod label-border">
+          {% if surfaceWaterRisk === "Low" %}
+          <strong class="govuk-tag govuk-tag--{{ surfaceWaterStyle }} label-mod label-border">
             Low<span class="govuk-visually-hidden"> within a scale of very low, low, medium and high.</span>
           </strong>
           {% else %}
@@ -34,8 +34,8 @@
           </strong>
           {% endif %}
 
-          {% if surfaceWaterRisk === "medium" %}
-          <strong class="govuk-tag govuk-tag--Medium label-mod label-border">
+          {% if surfaceWaterRisk === "Medium" %}
+          <strong class="govuk-tag govuk-tag--{{ surfaceWaterStyle }} label-mod label-border">
             Medium<span class="govuk-visually-hidden"> within a scale of very low, low, medium and high.</span>
           </strong>
           {% else %}
@@ -44,8 +44,8 @@
           </strong>
           {% endif %}
 
-          {% if surfaceWaterRisk === "high" %}
-          <strong class="govuk-tag govuk-tag--High label-mod label-border">
+          {% if surfaceWaterRisk === "High" %}
+          <strong class="govuk-tag govuk-tag--{{ surfaceWaterStyle }} label-mod label-border">
             High<span class="govuk-visually-hidden"> within a scale of very low, low, medium and high.</span>
           </strong>
           {% else %}
@@ -57,8 +57,8 @@
         <h3 class="govuk-heading-s govuk-!-padding-top-6 govuk-!-margin-bottom-0">Yearly chance of flooding between 2040
           and 2060</h3>
         <div class="risk-label-group govuk-!-margin-bottom-3">
-          {% if surfaceWaterRiskCC === "very low" %}
-          <strong class="govuk-tag govuk-tag--Very-low label-mod label-border">
+          {% if surfaceWaterRiskCC === "Very low" %}
+          <strong class="govuk-tag govuk-tag--{{ surfaceWaterCCStyle }} label-mod label-border">
             Very low<span class="govuk-visually-hidden"> within a scale of very low, low, medium and high.</span>
           </strong>
           {% else %}
@@ -67,8 +67,8 @@
           </strong>
           {% endif %}
 
-          {% if surfaceWaterRiskCC === "low" %}
-          <strong class="govuk-tag govuk-tag--Low label-mod label-border">
+          {% if surfaceWaterRiskCC === "Low" %}
+          <strong class="govuk-tag govuk-tag--{{ surfaceWaterCCStyle }} label-mod label-border">
             Low<span class="govuk-visually-hidden"> within a scale of very low, low, medium and high.</span>
           </strong>
           {% else %}
@@ -77,8 +77,8 @@
           </strong>
           {% endif %}
 
-          {% if surfaceWaterRiskCC === "medium" %}
-          <strong class="govuk-tag govuk-tag--Medium label-mod label-border">
+          {% if surfaceWaterRiskCC === "Medium" %}
+          <strong class="govuk-tag govuk-tag--{{ surfaceWaterCCStyle }} label-mod label-border">
             Medium<span class="govuk-visually-hidden"> within a scale of very low, low, medium and high.</span>
           </strong>
           {% else %}
@@ -87,8 +87,8 @@
           </strong>
           {% endif %}
 
-          {% if surfaceWaterRiskCC === "high" %}
-          <strong class="govuk-tag govuk-tag--High label-mod label-border">
+          {% if surfaceWaterRiskCC === "High" %}
+          <strong class="govuk-tag govuk-tag--{{ surfaceWaterCCStyle }} label-mod label-border">
             High<span class="govuk-visually-hidden"> within a scale of very low, low, medium and high.</span>
           </strong>
           {% else %}

--- a/server/views/rivers-and-sea.html
+++ b/server/views/rivers-and-sea.html
@@ -90,7 +90,7 @@ role="navigation">
       {% endif %}
 
       <h2 class="govuk-heading-l govuk-!-padding-top-6">What to do next</h2>
-      {% if riverAndSeaRisk !== 'Very Low' %}
+      {% if riverAndSeaRisk !== 'Very low' %}
       <p class="govuk-body">Sign up to <a class="govuk-link" href="https://www.gov.uk/sign-up-for-flood-warnings" 
         previewlistener="true">receive flood warnings by phone, text or email</a>.</p>
       {% endif %}


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/LTFRI-1620

When going into the ‘More about…’ Rivers and sea pages there is a difference in colour between the very low dynamic content at the first sentence.