### PR TITLE
Update README files, Licence definitions and CONTRIBUTING files

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -17,13 +17,13 @@
 # Check Your Long Term Flood Risk Services Front end application (cyltfr-app)
 Repo for the Check Your Long Term Flood (CYLTFR) service front end application.
 
-This repository is part of the CYLTFR service which also includes:
-<https://github.com/DEFRA/cyltfr-service>
-<https://github.com/DEFRA/cyltfr-data>
+This repository is part of the CYLTFR service which also includes:\
+<https://github.com/DEFRA/cyltfr-service>\
+<https://github.com/DEFRA/cyltfr-data>\
 <https://github.com/DEFRA/cyltfr-admin>
 
 ## Prerequisites
-Node v20.x
+Node v20.x\
 Docker v20.10.0+
 
 ### Build app

--- a/README.MD
+++ b/README.MD
@@ -135,19 +135,16 @@ or
 
 `$ npm run cx`
 
-## Contributing to this project
-Please read our [contribution guidelines](https://github.com/DEFRA/cyltfr-app/blob/develop/CONTRIBUTING.md)
-
 ## License
 THIS INFORMATION IS LICENSED UNDER THE CONDITIONS OF THE OPEN GOVERNMENT LICENCE found at:
 
-http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3
+<http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3>
 
 The following attribution statement MUST be cited in your products and applications when using this information.
 
-Contains public sector information licensed under the Open Government license v3
+>Contains public sector information licensed under the Open Government licence v3
 
 ### About the license
-The Open Government Licence (OGL) was developed by the Controller of Her Majesty's Stationery Office (HMSO) to enable information providers in the public sector to license the use and re-use of their information under a common open licence.
+The Open Government Licence (OGL) was developed by the Controller of His Majesty's Stationery Office (HMSO) to enable information providers in the public sector to license the use and re-use of their information under a common open licence.
 
 It is designed to encourage use and re-use of information freely and flexibly, with only a few conditions.

--- a/README.MD
+++ b/README.MD
@@ -15,8 +15,12 @@
 [![Licence](https://img.shields.io/badge/licence-OGLv3-blue.svg)](http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3)
 
 # Check Your Long Term Flood Risk Services Front end application (cyltfr-app)
-Repo for the Check Your Long Term Flood service front end application.
+Repo for the Check Your Long Term Flood (CYLTFR) service front end application.
 
+This repository is part of the CYLTFR service which also includes:
+<https://github.com/DEFRA/cyltfr-service>
+<https://github.com/DEFRA/cyltfr-data>
+<https://github.com/DEFRA/cyltfr-admin>
 
 ## Prerequisites
 Node v20.x

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "risk-app",
-  "version": "4.3.0",
+  "version": "5.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "risk-app",
-      "version": "4.3.0",
+      "version": "5.0.0",
       "license": "OGL-UK-3.0",
       "dependencies": {
         "@airbrake/node": "^2.1.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "risk-app",
-  "version": "4.3.0",
+  "version": "5.0.0",
   "description": "Long term flood risk information",
   "main": "index.js",
   "engines": {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/LTFRI-1566

The README should be updated with the latest recommendations about referencing the licence. A CONTIBUTING file should be added, and the link in the README file corrected and the version number to 5.0.0