### PR TITLE
Show flooding toggle not working on technical map

### DIFF
--- a/server/src/js/map-page/map-page.js
+++ b/server/src/js/map-page/map-page.js
@@ -163,10 +163,19 @@ function mapPage () {
     mapController.setCurrent(ref)
     const selectedAddressCheckbox = document.getElementById('selected-address-checkbox')
     const showFloodingCheckbox = document.getElementById('display-layers-checkbox')
+    const techMapShowFloodingCheckbox = document.querySelectorAll('.display-layers-checkbox-toggle')
     const mapReferenceValue = selectedOption()
 
     const displayMapRef = showFloodingCheckbox.checked ? mapReferenceValue : `${mapReferenceValue}DONOTDISPLAY`
     mapPageConsts.maps.showMap(`${displayMapRef}`, selectedAddressCheckbox.checked)
+
+    // Show or hide the flooding layers on the tech map
+    techMapShowFloodingCheckbox.forEach((checkbox) => {
+      checkbox.addEventListener('change', () => {
+        const displayMapRef = checkbox.checked ? mapReferenceValue : `${mapReferenceValue}DONOTDISPLAY`
+        mapPageConsts.maps.showMap(`${displayMapRef}`, selectedAddressCheckbox.checked)
+      })
+    })
   }
 
   // Default to the first category/map
@@ -387,7 +396,6 @@ mapPageConsts.scenarioRadioButtons.forEach(function (radio) {
 if (!mapPageConsts.params.includes('map=')) {
   mapPageConsts.rsAndResOptions.classList.remove('hide')
   mapPageConsts.selectedAddressCheckbox.classList.add('hide')
-  mapPageConsts.selectedAddressToggle.forEach((element) => element.classList.add('hide'))
 }
 
 // Update first radio to checked when changing to other key option

--- a/server/views/partials/map-page/key/toggles.html
+++ b/server/views/partials/map-page/key/toggles.html
@@ -6,7 +6,7 @@
     </legend>
     <div class="govuk-radios govuk-checkboxes govuk-checkboxes--small" data-module="govuk-checkboxes">
       <div class="govuk-checkboxes__item">
-        <input class="govuk-checkboxes__input govuk-radios__inputs" id="display-layers-checkbox" tabindex="2" name="map-toggle" type="checkbox"
+        <input class="govuk-checkboxes__input govuk-radios__inputs display-layers-checkbox-toggle" id="display-layers-checkbox" tabindex="2" name="map-toggle" type="checkbox"
           value="30" checked="">
         <label class="govuk-label govuk-checkboxes__label" for="display-layers-checkbox">
           Show flooding


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/LTFRI-1697

Technical map R&S and reservoir ‘show flooding’ toggle does not work. It should hide the flood layer when toggled off and show it again when toggled on.