### PR TITLE
/os-get-token route is filling logs

### DIFF
--- a/server/routes/__tests__/os-get-token.spec.js
+++ b/server/routes/__tests__/os-get-token.spec.js
@@ -50,7 +50,7 @@ describe('/os-get-token page', () => {
 
     options.url = '/os-get-token'
     const tokenResponse = await server.inject(options)
-    expect(tokenResponse.statusCode).toEqual(STATUS_CODES.HTTP_STATUS_NO_CONTENT) // 204
+    expect(tokenResponse.statusCode).toEqual(STATUS_CODES.HTTP_STATUS_OK) // 200
   })
 
   test('catch with 400 error if there are any failures in OS API call', async () => {
@@ -69,6 +69,6 @@ describe('/os-get-token page', () => {
 
     options.url = '/os-get-token'
     const tokenResponse = await server.inject(options)
-    expect(tokenResponse.statusCode).toEqual(STATUS_CODES.HTTP_STATUS_BAD_REQUEST) // 400
+    expect(tokenResponse.statusCode).toEqual(STATUS_CODES.HTTP_STATUS_SERVICE_UNAVAILABLE) // 503
   })
 })

--- a/server/routes/__tests__/os-get-token.spec.js
+++ b/server/routes/__tests__/os-get-token.spec.js
@@ -1,6 +1,7 @@
 const STATUS_CODES = require('http2').constants
 const createServer = require('../../../server')
 const { mockOptions } = require('../../../test/mock')
+const osApi = require('../../services/osapi')
 let server, cookie
 
 jest.mock('../../config')
@@ -24,7 +25,7 @@ afterAll(async () => {
 })
 
 describe('/os-get-token page', () => {
-  test('/os-get-token without map page visit', async () => {
+  test('/os-get-token without map page visit returns error but still returns 200ok', async () => {
     const options = {
       method: 'GET',
       url: '/os-get-token'
@@ -35,7 +36,7 @@ describe('/os-get-token page', () => {
     expect(response.result).toEqual({ error: 'Ordnance survey Token fetch failed. Map token expired.' })
   })
 
-  test('/os-get-token with map page visit', async () => {
+  test('/os-get-token with map page visit returns OS API token payload', async () => {
     const options = {
       method: 'GET',
       url: '/map',
@@ -50,5 +51,24 @@ describe('/os-get-token page', () => {
     options.url = '/os-get-token'
     const tokenResponse = await server.inject(options)
     expect(tokenResponse.statusCode).toEqual(STATUS_CODES.HTTP_STATUS_NO_CONTENT) // 204
+  })
+
+  test('catch with 400 error if there are any failures in OS API call', async () => {
+    const options = {
+      method: 'GET',
+      url: '/map',
+      headers: {
+        cookie
+      }
+    }
+
+    const response = await server.inject(options)
+    expect(response.statusCode).toEqual(STATUS_CODES.HTTP_STATUS_OK) // 200
+
+    osApi.osGetAccessToken.mockImplementation(() => { throw new Error('osGetToken') })
+
+    options.url = '/os-get-token'
+    const tokenResponse = await server.inject(options)
+    expect(tokenResponse.statusCode).toEqual(STATUS_CODES.HTTP_STATUS_BAD_REQUEST) // 400
   })
 })

--- a/server/routes/__tests__/os-get-token.spec.js
+++ b/server/routes/__tests__/os-get-token.spec.js
@@ -31,7 +31,8 @@ describe('/os-get-token page', () => {
     }
 
     const response = await server.inject(options)
-    expect(response.statusCode).toEqual(STATUS_CODES.HTTP_STATUS_BAD_REQUEST) // 400
+    expect(response.statusCode).toEqual(STATUS_CODES.HTTP_STATUS_OK) // 200
+    expect(response.result).toEqual({ error: 'Ordnance survey Token fetch failed. Map token expired.' })
   })
 
   test('/os-get-token with map page visit', async () => {

--- a/server/routes/os-get-token.js
+++ b/server/routes/os-get-token.js
@@ -2,6 +2,8 @@ const Boom = require('@hapi/boom')
 const errors = require('../models/errors.json')
 const osApi = require('../services/osapi')
 
+const HTTP_STATUS_OK = 200
+
 module.exports = {
   method: 'GET',
   path: '/os-get-token',
@@ -9,7 +11,7 @@ module.exports = {
     try {
       const mapTokenExpiry = request.yar.get('mapTokenExpiry')
       if (Date.now() > mapTokenExpiry) {
-        return h.response({ error: errors.osGetTokenMapExpired.message }).code(200)
+        return h.response({ error: errors.osGetTokenMapExpired.message }).code(HTTP_STATUS_OK)
       }
       const payload = await osApi.osGetAccessToken()
       return h.response(payload).type('application/json')

--- a/server/routes/os-get-token.js
+++ b/server/routes/os-get-token.js
@@ -16,7 +16,7 @@ module.exports = {
       const payload = await osApi.osGetAccessToken()
       return h.response(payload).type('application/json')
     } catch (err) {
-      return Boom.badRequest(errors.osGetToken, err)
+      return Boom.serverUnavailable(errors.osGetToken, err)
     }
   },
   options: {

--- a/server/routes/os-get-token.js
+++ b/server/routes/os-get-token.js
@@ -9,7 +9,7 @@ module.exports = {
     try {
       const mapTokenExpiry = request.yar.get('mapTokenExpiry')
       if (Date.now() > mapTokenExpiry) {
-        return Boom.badRequest(errors.osGetTokenMapExpired.message)
+        return h.response({ error: errors.osGetTokenMapExpired.message }).code(200)
       }
       const payload = await osApi.osGetAccessToken()
       return h.response(payload).type('application/json')

--- a/server/services/__mocks__/osapi.js
+++ b/server/services/__mocks__/osapi.js
@@ -1,4 +1,4 @@
-const osGetAccessToken = jest.fn(() => { return Promise.resolve(() => { return { access_token: '', expires_in: 600 } }) })
+const osGetAccessToken = jest.fn(() => { return Promise.resolve({ access_token: '', expires_in: 600 }) })
 
 module.exports = {
   osGetAccessToken

--- a/server/src/js/map.js
+++ b/server/src/js/map.js
@@ -19,14 +19,14 @@ async function refreshOsToken () {
   tokenFetchRunning = true
   const response = await fetch('/os-get-token')
   tokenFetchRunning = false
-  if (response.ok) {
-    const tokenValues = await response.json()
-    window.mapConfig.osToken = tokenValues.access_token
+  const formattedResponse = await response.json()
+  if (formattedResponse.error) {
+    throw new Error('os-get-token failed')
+  } else {
+    window.mapConfig.osToken = formattedResponse.access_token
     setTimeout(() => {
       refreshOsToken()
-    }, (tokenValues.expires_in - TOKEN_PREFETCH_SECS) * 1000)
-  } else {
-    throw new Error('os-get-token failed')
+    }, (formattedResponse.expires_in - TOKEN_PREFETCH_SECS) * 1000)
   }
 }
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/LTFRI-1753

/os-get-token route should return a JSON error result and not throw a 400 error.