### PR TITLE
hide very low depth extents on surface water (map only)

### DIFF
--- a/server/views/partials/map-page/key/surfaceWater.html
+++ b/server/views/partials/map-page/key/surfaceWater.html
@@ -111,17 +111,6 @@
                     <span class="risk-severity-text">Low chance</span>
                     <span class="risk-context">Between 0.1% and 1% chance each year</span>
                   </span>
-                  <span
-                    class="defra-map-key__symbol-container-v3 defra-map-key__symbol-container--multi sw-extent-container"
-                    id="sw-depth-very-low">
-                    <span class="defra-map-key__symbol">
-                      <svg class="risk-square-svg" aria-hidden="true" focusable="false" viewBox="0 0 36 36">
-                        <rect class="very-low-symbol risk-colour-square" x="5" y="5"></rect>
-                      </svg>
-                    </span>
-                    <span class="risk-severity-text">Very low chance</span>
-                    <span class="risk-context">Less than 0.1% chance each year</span>
-                  </span>
                   
                 </div>
               </label>
@@ -222,17 +211,6 @@
                     </span>
                     <span class="risk-severity-text">Low chance</span>
                     <span class="risk-context">Between 0.1% and 1% chance each year</span>
-                  </span>
-                  <span
-                    class="defra-map-key__symbol-container-v3 defra-map-key__symbol-container--multi sw-extent-container"
-                    id="sw-depth-cc-very-low">
-                    <span class="defra-map-key__symbol">
-                      <svg class="risk-square-svg" aria-hidden="true" focusable="false" viewBox="0 0 36 36">
-                        <rect class="very-low-symbol risk-colour-square" x="5" y="5"></rect>
-                      </svg>
-                    </span>
-                    <span class="risk-severity-text">Very low chance</span>
-                    <span class="risk-context">Less than 0.1% chance each year</span>
                   </span>
                   
                 </div>


### PR DESCRIPTION
https://eaflood.atlassian.net/jira/software/c/projects/LTFRI/boards/589?selectedIssue=LTFRI-1784

This update removes very low depth extent from surface water map key.