### PR TITLE
Remove radius parameter from getByCoordinates call in cyltfr-service

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "risk-app",
-  "version": "5.0.0",
+  "version": "5.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "risk-app",
-      "version": "5.0.0",
+      "version": "5.1.0",
       "license": "OGL-UK-3.0",
       "dependencies": {
         "@airbrake/node": "^2.1.8",

--- a/server/routes/__tests__/risk.spec.js
+++ b/server/routes/__tests__/risk.spec.js
@@ -111,7 +111,7 @@ describe('Risk page test', () => {
   })
 
   test('/risk - Risk service error', async () => {
-    riskService.getByCoordinates.mockImplementationOnce((_x, _y, _radius) => {
+    riskService.getByCoordinates.mockImplementationOnce((_x, _y) => {
       return Promise.reject(new Error('Error calling risk'))
     })
 

--- a/server/routes/ground-water.js
+++ b/server/routes/ground-water.js
@@ -14,11 +14,10 @@ module.exports = {
     }
 
     const { x, y } = address
-    const radius = 15
     const backLinkUri = '/risk'
 
     try {
-      const risk = await request.server.methods.riskService(x, y, radius)
+      const risk = await request.server.methods.riskService(x, y)
       const hasError = risk.riverAndSeaRisk?.error ||
         risk.surfaceWaterRisk?.error ||
         risk.reservoirDryRisk?.error ||

--- a/server/routes/risk.js
+++ b/server/routes/risk.js
@@ -19,10 +19,9 @@ module.exports = {
       }
 
       const { x, y } = address
-      const radius = 15
 
       try {
-        const risk = await request.server.methods.riskService(x, y, radius)
+        const risk = await request.server.methods.riskService(x, y)
 
         const hasError = risk.riverAndSeaRisk?.error ||
         risk.surfaceWaterRisk?.error ||

--- a/server/routes/rivers-and-sea.js
+++ b/server/routes/rivers-and-sea.js
@@ -18,11 +18,10 @@ module.exports = {
     }
 
     const { x, y } = address
-    const radius = 15
     const backLinkUri = '/risk'
 
     try {
-      const risk = await request.server.methods.riskService(x, y, radius)
+      const risk = await request.server.methods.riskService(x, y)
       const hasError = risk.riverAndSeaRisk?.error ||
         risk.surfaceWaterRisk?.error ||
         risk.reservoirDryRisk?.error ||

--- a/server/routes/surface-water.js
+++ b/server/routes/surface-water.js
@@ -19,11 +19,10 @@ module.exports = {
       }
 
       const { x, y } = address
-      const radius = 15
       const backLinkUri = '/risk'
 
       try {
-        const risk = await request.server.methods.riskService(x, y, radius)
+        const risk = await request.server.methods.riskService(x, y)
         const hasError = risk.riverAndSeaRisk?.error ||
             risk.surfaceWaterRisk?.error ||
             risk.reservoirDryRisk?.error ||

--- a/server/server-methods/__tests__/server-methods-disabled-cache.spec.js
+++ b/server/server-methods/__tests__/server-methods-disabled-cache.spec.js
@@ -11,7 +11,6 @@ const defaultOptions = {
 
 const x = 40.7128
 const y = -74.0060
-const radius = 15
 const location = 'WA4 1AB'
 
 jest.mock('../../services/flood')
@@ -89,7 +88,7 @@ describe('server methods', () => {
     })
 
     test('should return updated risk details', async () => {
-      const response = await server.methods.riskService(x, y, radius)
+      const response = await server.methods.riskService(x, y)
 
       expect(response).toEqual(
         expect.objectContaining({
@@ -106,7 +105,7 @@ describe('server methods', () => {
 
       riskService.__updateReturnValue({ leadLocalFloodAuthority: 'Wessex' })
 
-      const changedResponse = await server.methods.riskService(x, y, radius)
+      const changedResponse = await server.methods.riskService(x, y)
 
       expect(changedResponse).toEqual(
         expect.objectContaining({

--- a/server/server-methods/__tests__/server-methods-enabled-cache.spec.js
+++ b/server/server-methods/__tests__/server-methods-enabled-cache.spec.js
@@ -12,7 +12,6 @@ const defaultOptions = {
 
 const x = 40.7128
 const y = -74.0060
-const radius = 15
 const location = 'WA4 1AB'
 
 jest.mock('../../services/flood')
@@ -91,7 +90,7 @@ describe('server methods', () => {
     })
 
     test('should return original cached risk details', async () => {
-      const response = await server.methods.riskService(x, y, radius)
+      const response = await server.methods.riskService(x, y)
 
       expect(response).toEqual(
         expect.objectContaining({
@@ -108,7 +107,7 @@ describe('server methods', () => {
 
       riskService.__updateReturnValue({ leadLocalFloodAuthority: 'Wessex' })
 
-      const changedResponse = await server.methods.riskService(x, y, radius)
+      const changedResponse = await server.methods.riskService(x, y)
 
       expect(changedResponse).toEqual(
         expect.objectContaining({

--- a/server/services/__mocks__/risk.js
+++ b/server/services/__mocks__/risk.js
@@ -23,7 +23,7 @@ riskService.__resetReturnValue = function () {
   returnValue = { ...originalReturnValue }
 }
 
-riskService.getByCoordinates.mockImplementation((_x, _y, _radius) => {
+riskService.getByCoordinates.mockImplementation((_x, _y) => {
   return Promise.resolve(returnValue)
 })
 

--- a/server/services/__tests__/risk.spec.js
+++ b/server/services/__tests__/risk.spec.js
@@ -12,8 +12,8 @@ describe('Risk service', () => {
   })
 
   test('Calls getByCoordinates', async () => {
-    risk.getByCoordinates(1, 2, 3)
-    expect(util.getJson).toHaveBeenCalledWith('http://localhost:8050/floodrisk/1/2/3')
+    risk.getByCoordinates(1, 2)
+    expect(util.getJson).toHaveBeenCalledWith('http://localhost:8050/floodrisk/1/2')
   })
 
   test('Calls swdepth', async () => {

--- a/server/services/risk.js
+++ b/server/services/risk.js
@@ -1,8 +1,8 @@
 const util = require('../util')
 const config = require('../config')
 
-function getByCoordinates (x, y, radius) {
-  const uri = `${config.serviceUrl}/floodrisk/${x}/${y}/${radius}`
+function getByCoordinates (x, y) {
+  const uri = `${config.serviceUrl}/floodrisk/${x}/${y}`
 
   return util.getJson(uri)
 }


### PR DESCRIPTION
https://eaflood.atlassian.net/jira/software/c/projects/LTFRI/boards/589?selectedIssue=LTFRI-1509

This changes removes the radius parameter as this is not required for Nafra2.