### PR TITLE
Hide very low depth extents on surface water (map only)

### DIFF
--- a/server/models/definition/05/maps.json
+++ b/server/models/definition/05/maps.json
@@ -569,6 +569,12 @@
                 "icon": "light blue"
               }
             ]
+          },
+          "styleOverride": {
+            "paint": {
+              "fill-color": "#FFCCCB",
+              "opacity": 0.5
+            }
           }
         },
         {

--- a/server/models/definition/05/maps.json
+++ b/server/models/definition/05/maps.json
@@ -571,10 +571,91 @@
             ]
           },
           "styleOverride": {
-            "paint": {
-              "fill-color": "#FFCCCB",
-              "opacity": 0.5
-            }
+            "version": 8,
+            "sprite": "../sprites/sprite",
+            "glyphs": "../fonts/{fontstack}/{range}.pbf",
+            "sources": {
+              "esri": {
+                "type": "vector",
+                "bounds": [
+                  -6.98424,
+                  49.8816,
+                  2.07311,
+                  55.8115
+                ],
+                "minzoom": 1,
+                "maxzoom": 14,
+                "scheme": "xyz",
+                "url": "../../"
+              }
+            },
+            "layers": [
+              {
+                "id": "Risk of Flooding from Surface Water Depth CCSW1 > 300mm/High/1",
+                "type": "fill",
+                "source": "esri",
+                "source-layer": "Risk of Flooding from Surface Water Depth CCSW1 > 300mm",
+                "filter": [
+                  "==",
+                  "_symbol",
+                  0
+                ],
+                "minzoom": 4.7597,
+                "layout": {},
+                "paint": {
+                  "fill-color": "#555C9D"
+                }
+              },
+              {
+                "id": "Risk of Flooding from Surface Water Depth CCSW1 > 300mm/Medium/1",
+                "type": "fill",
+                "source": "esri",
+                "source-layer": "Risk of Flooding from Surface Water Depth CCSW1 > 300mm",
+                "filter": [
+                  "==",
+                  "_symbol",
+                  1
+                ],
+                "minzoom": 4.7597,
+                "layout": {},
+                "paint": {
+                  "fill-color": "#9AA0DE"
+                }
+              },
+              {
+                "id": "Risk of Flooding from Surface Water Depth CCSW1 > 300mm/Low/1",
+                "type": "fill",
+                "source": "esri",
+                "source-layer": "Risk of Flooding from Surface Water Depth CCSW1 > 300mm",
+                "filter": [
+                  "==",
+                  "_symbol",
+                  2
+                ],
+                "minzoom": 4.7597,
+                "layout": {},
+                "paint": {
+                  "fill-color": "#C4E1FF"
+                }
+              },
+              {
+                "id": "Risk of Flooding from Surface Water Depth CCSW1 > 300mm/Very low/1",
+                "type": "fill",
+                "source": "esri",
+                "source-layer": "Risk of Flooding from Surface Water Depth CCSW1 > 300mm",
+                "filter": [
+                  "==",
+                  "_symbol",
+                  3
+                ],
+                "minzoom": 4.7597,
+                "layout": {},
+                "paint": {
+                  "fill-color": "#CCCCCC",
+                  "fill-opacity": 0
+                }
+              }
+            ]
           }
         },
         {

--- a/server/models/definition/05/maps.json
+++ b/server/models/definition/05/maps.json
@@ -429,6 +429,93 @@
                 "icon": "light blue"
               }
             ]
+          },
+          "styleOverride": {
+            "version": 8,
+            "sprite": "../sprites/sprite",
+            "glyphs": "../fonts/{fontstack}/{range}.pbf",
+            "sources": {
+              "esri": {
+                "type": "vector",
+                "bounds": [
+                  -6.98424,
+                  49.8816,
+                  2.07311,
+                  55.8115
+                ],
+                "minzoom": 1,
+                "maxzoom": 14,
+                "scheme": "xyz",
+                "url": "../../"
+              }
+            },
+            "layers": [
+              {
+                "id": "Risk of Flooding from Surface Water Depth > 200mm/High/1",
+                "type": "fill",
+                "source": "esri",
+                "source-layer": "Risk of Flooding from Surface Water Depth > 200mm",
+                "filter": [
+                  "==",
+                  "_symbol",
+                  0
+                ],
+                "minzoom": 4.7597,
+                "layout": {},
+                "paint": {
+                  "fill-color": "#555C9D"
+                }
+              },
+              {
+                "id": "Risk of Flooding from Surface Water Depth > 200mm/Medium/1",
+                "type": "fill",
+                "source": "esri",
+                "source-layer": "Risk of Flooding from Surface Water Depth > 200mm",
+                "filter": [
+                  "==",
+                  "_symbol",
+                  1
+                ],
+                "minzoom": 4.7597,
+                "layout": {},
+                "paint": {
+                  "fill-color": "#9AA0DE"
+                }
+              },
+              {
+                "id": "Risk of Flooding from Surface Water Depth > 200mm/Low/1",
+                "type": "fill",
+                "source": "esri",
+                "source-layer": "Risk of Flooding from Surface Water Depth > 200mm",
+                "filter": [
+                  "==",
+                  "_symbol",
+                  2
+                ],
+                "minzoom": 4.7597,
+                "layout": {},
+                "paint": {
+                  "fill-color": "#C4E1FF"
+                }
+              },
+              {
+                "id": "Risk of Flooding from Surface Water Depth > 200mm/Very low/1",
+                "type": "fill",
+                "source": "esri",
+                "source-layer": "Risk of Flooding from Surface Water Depth > 200mm",
+                "filter": [
+                  "==",
+                  "_symbol",
+                  3
+                ],
+                "minzoom": 4.7597,
+                "layout": {},
+                "paint": {
+                  "fill-color": "#CCCCCC",
+                  "fill-opacity": 0
+                }
+              }
+            ]
           }
         },
         {
@@ -455,6 +542,93 @@
               {
                 "text": "Up to 200mm",
                 "icon": "light blue"
+              }
+            ]
+          },
+          "styleOverride": {
+            "version": 8,
+            "sprite": "../sprites/sprite",
+            "glyphs": "../fonts/{fontstack}/{range}.pbf",
+            "sources": {
+              "esri": {
+                "type": "vector",
+                "bounds": [
+                  -6.98424,
+                  49.8816,
+                  2.07311,
+                  55.8115
+                ],
+                "minzoom": 1,
+                "maxzoom": 14,
+                "scheme": "xyz",
+                "url": "../../"
+              }
+            },
+            "layers": [
+              {
+                "id": "Risk of Flooding from Surface Water Depth > 300mm/High/1",
+                "type": "fill",
+                "source": "esri",
+                "source-layer": "Risk of Flooding from Surface Water Depth > 300mm",
+                "filter": [
+                  "==",
+                  "_symbol",
+                  0
+                ],
+                "minzoom": 4.7597,
+                "layout": {},
+                "paint": {
+                  "fill-color": "#555C9D"
+                }
+              },
+              {
+                "id": "Risk of Flooding from Surface Water Depth > 300mm/Medium/1",
+                "type": "fill",
+                "source": "esri",
+                "source-layer": "Risk of Flooding from Surface Water Depth > 300mm",
+                "filter": [
+                  "==",
+                  "_symbol",
+                  1
+                ],
+                "minzoom": 4.7597,
+                "layout": {},
+                "paint": {
+                  "fill-color": "#9AA0DE"
+                }
+              },
+              {
+                "id": "Risk of Flooding from Surface Water Depth > 300mm/Low/1",
+                "type": "fill",
+                "source": "esri",
+                "source-layer": "Risk of Flooding from Surface Water Depth > 300mm",
+                "filter": [
+                  "==",
+                  "_symbol",
+                  2
+                ],
+                "minzoom": 4.7597,
+                "layout": {},
+                "paint": {
+                  "fill-color": "#C4E1FF"
+                }
+              },
+              {
+                "id": "Risk of Flooding from Surface Water Depth > 300mm/Very low/1",
+                "type": "fill",
+                "source": "esri",
+                "source-layer": "Risk of Flooding from Surface Water Depth > 300mm",
+                "filter": [
+                  "==",
+                  "_symbol",
+                  3
+                ],
+                "minzoom": 4.7597,
+                "layout": {},
+                "paint": {
+                  "fill-color": "#CCCCCC",
+                  "fill-opacity": 0
+                }
               }
             ]
           }
@@ -485,6 +659,93 @@
                 "icon": "light blue"
               }
             ]
+          },
+          "styleOverride": {
+            "version": 8,
+            "sprite": "../sprites/sprite",
+            "glyphs": "../fonts/{fontstack}/{range}.pbf",
+            "sources": {
+              "esri": {
+                "type": "vector",
+                "bounds": [
+                  -6.98424,
+                  49.8816,
+                  2.07311,
+                  55.8115
+                ],
+                "minzoom": 1,
+                "maxzoom": 14,
+                "scheme": "xyz",
+                "url": "../../"
+              }
+            },
+            "layers": [
+              {
+                "id": "Risk of Flooding from Surface Water Depth > 600mm/High/1",
+                "type": "fill",
+                "source": "esri",
+                "source-layer": "Risk of Flooding from Surface Water Depth > 600mm",
+                "filter": [
+                  "==",
+                  "_symbol",
+                  0
+                ],
+                "minzoom": 4.7597,
+                "layout": {},
+                "paint": {
+                  "fill-color": "#555C9D"
+                }
+              },
+              {
+                "id": "Risk of Flooding from Surface Water Depth > 600mm/Medium/1",
+                "type": "fill",
+                "source": "esri",
+                "source-layer": "Risk of Flooding from Surface Water Depth > 600mm",
+                "filter": [
+                  "==",
+                  "_symbol",
+                  1
+                ],
+                "minzoom": 4.7597,
+                "layout": {},
+                "paint": {
+                  "fill-color": "#9AA0DE"
+                }
+              },
+              {
+                "id": "Risk of Flooding from Surface Water Depth > 600mm/Low/1",
+                "type": "fill",
+                "source": "esri",
+                "source-layer": "Risk of Flooding from Surface Water Depth > 600mm",
+                "filter": [
+                  "==",
+                  "_symbol",
+                  2
+                ],
+                "minzoom": 4.7597,
+                "layout": {},
+                "paint": {
+                  "fill-color": "#C4E1FF"
+                }
+              },
+              {
+                "id": "Risk of Flooding from Surface Water Depth > 600mm/Very low/1",
+                "type": "fill",
+                "source": "esri",
+                "source-layer": "Risk of Flooding from Surface Water Depth > 600mm",
+                "filter": [
+                  "==",
+                  "_symbol",
+                  3
+                ],
+                "minzoom": 4.7597,
+                "layout": {},
+                "paint": {
+                  "fill-color": "#CCCCCC",
+                  "fill-opacity": 0
+                }
+              }
+            ]
           }
         },
         {
@@ -511,6 +772,93 @@
               {
                 "text": "Up to 200mm",
                 "icon": "light blue"
+              }
+            ]
+          },
+          "styleOverride": {
+            "version": 8,
+            "sprite": "../sprites/sprite",
+            "glyphs": "../fonts/{fontstack}/{range}.pbf",
+            "sources": {
+              "esri": {
+                "type": "vector",
+                "bounds": [
+                  -6.98424,
+                  49.8816,
+                  2.07311,
+                  55.8115
+                ],
+                "minzoom": 1,
+                "maxzoom": 14,
+                "scheme": "xyz",
+                "url": "../../"
+              }
+            },
+            "layers": [
+              {
+                "id": "Risk of Flooding from Surface Water Depth > 900mm/High/1",
+                "type": "fill",
+                "source": "esri",
+                "source-layer": "Risk of Flooding from Surface Water Depth > 900mm",
+                "filter": [
+                  "==",
+                  "_symbol",
+                  0
+                ],
+                "minzoom": 4.7597,
+                "layout": {},
+                "paint": {
+                  "fill-color": "#555C9D"
+                }
+              },
+              {
+                "id": "Risk of Flooding from Surface Water Depth > 900mm/Medium/1",
+                "type": "fill",
+                "source": "esri",
+                "source-layer": "Risk of Flooding from Surface Water Depth > 900mm",
+                "filter": [
+                  "==",
+                  "_symbol",
+                  1
+                ],
+                "minzoom": 4.7597,
+                "layout": {},
+                "paint": {
+                  "fill-color": "#9AA0DE"
+                }
+              },
+              {
+                "id": "Risk of Flooding from Surface Water Depth > 900mm/Low/1",
+                "type": "fill",
+                "source": "esri",
+                "source-layer": "Risk of Flooding from Surface Water Depth > 900mm",
+                "filter": [
+                  "==",
+                  "_symbol",
+                  2
+                ],
+                "minzoom": 4.7597,
+                "layout": {},
+                "paint": {
+                  "fill-color": "#C4E1FF"
+                }
+              },
+              {
+                "id": "Risk of Flooding from Surface Water Depth > 900mm/Very low/1",
+                "type": "fill",
+                "source": "esri",
+                "source-layer": "Risk of Flooding from Surface Water Depth > 900mm",
+                "filter": [
+                  "==",
+                  "_symbol",
+                  3
+                ],
+                "minzoom": 4.7597,
+                "layout": {},
+                "paint": {
+                  "fill-color": "#CCCCCC",
+                  "fill-opacity": 0
+                }
               }
             ]
           }

--- a/server/models/definition/05/maps.json
+++ b/server/models/definition/05/maps.json
@@ -541,6 +541,93 @@
                 "icon": "light blue"
               }
             ]
+          },
+          "styleOverride": {
+            "version": 8,
+            "sprite": "../sprites/sprite",
+            "glyphs": "../fonts/{fontstack}/{range}.pbf",
+            "sources": {
+              "esri": {
+                "type": "vector",
+                "bounds": [
+                  -6.98424,
+                  49.8816,
+                  2.07311,
+                  55.8115
+                ],
+                "minzoom": 1,
+                "maxzoom": 14,
+                "scheme": "xyz",
+                "url": "../../"
+              }
+            },
+            "layers": [
+              {
+                "id": "Risk of Flooding from Surface Water Depth CCSW1 > 200mm/High/1",
+                "type": "fill",
+                "source": "esri",
+                "source-layer": "Risk of Flooding from Surface Water Depth CCSW1 > 200mm",
+                "filter": [
+                  "==",
+                  "_symbol",
+                  0
+                ],
+                "minzoom": 4.7597,
+                "layout": {},
+                "paint": {
+                  "fill-color": "#555C9D"
+                }
+              },
+              {
+                "id": "Risk of Flooding from Surface Water Depth CCSW1 > 200mm/Medium/1",
+                "type": "fill",
+                "source": "esri",
+                "source-layer": "Risk of Flooding from Surface Water Depth CCSW1 > 200mm",
+                "filter": [
+                  "==",
+                  "_symbol",
+                  1
+                ],
+                "minzoom": 4.7597,
+                "layout": {},
+                "paint": {
+                  "fill-color": "#9AA0DE"
+                }
+              },
+              {
+                "id": "Risk of Flooding from Surface Water Depth CCSW1 > 200mm/Low/1",
+                "type": "fill",
+                "source": "esri",
+                "source-layer": "Risk of Flooding from Surface Water Depth CCSW1 > 200mm",
+                "filter": [
+                  "==",
+                  "_symbol",
+                  2
+                ],
+                "minzoom": 4.7597,
+                "layout": {},
+                "paint": {
+                  "fill-color": "#C4E1FF"
+                }
+              },
+              {
+                "id": "Risk of Flooding from Surface Water Depth CCSW1 > 200mm/Very low/1",
+                "type": "fill",
+                "source": "esri",
+                "source-layer": "Risk of Flooding from Surface Water Depth CCSW1 > 200mm",
+                "filter": [
+                  "==",
+                  "_symbol",
+                  3
+                ],
+                "minzoom": 4.7597,
+                "layout": {},
+                "paint": {
+                  "fill-color": "#CCCCCC",
+                  "fill-opacity": 0
+                }
+              }
+            ]
           }
         },
         {
@@ -684,6 +771,93 @@
                 "icon": "light blue"
               }
             ]
+          },
+          "styleOverride": {
+            "version": 8,
+            "sprite": "../sprites/sprite",
+            "glyphs": "../fonts/{fontstack}/{range}.pbf",
+            "sources": {
+              "esri": {
+                "type": "vector",
+                "bounds": [
+                  -6.98424,
+                  49.8816,
+                  2.07311,
+                  55.8115
+                ],
+                "minzoom": 1,
+                "maxzoom": 14,
+                "scheme": "xyz",
+                "url": "../../"
+              }
+            },
+            "layers": [
+              {
+                "id": "Risk of Flooding from Surface Water Depth CCSW1 > 600mm/High/1",
+                "type": "fill",
+                "source": "esri",
+                "source-layer": "Risk of Flooding from Surface Water Depth CCSW1 > 600mm",
+                "filter": [
+                  "==",
+                  "_symbol",
+                  0
+                ],
+                "minzoom": 4.7597,
+                "layout": {},
+                "paint": {
+                  "fill-color": "#555C9D"
+                }
+              },
+              {
+                "id": "Risk of Flooding from Surface Water Depth CCSW1 > 600mm/Medium/1",
+                "type": "fill",
+                "source": "esri",
+                "source-layer": "Risk of Flooding from Surface Water Depth CCSW1 > 600mm",
+                "filter": [
+                  "==",
+                  "_symbol",
+                  1
+                ],
+                "minzoom": 4.7597,
+                "layout": {},
+                "paint": {
+                  "fill-color": "#9AA0DE"
+                }
+              },
+              {
+                "id": "Risk of Flooding from Surface Water Depth CCSW1 > 600mm/Low/1",
+                "type": "fill",
+                "source": "esri",
+                "source-layer": "Risk of Flooding from Surface Water Depth CCSW1 > 600mm",
+                "filter": [
+                  "==",
+                  "_symbol",
+                  2
+                ],
+                "minzoom": 4.7597,
+                "layout": {},
+                "paint": {
+                  "fill-color": "#C4E1FF"
+                }
+              },
+              {
+                "id": "Risk of Flooding from Surface Water Depth CCSW1 > 600mm/Very low/1",
+                "type": "fill",
+                "source": "esri",
+                "source-layer": "Risk of Flooding from Surface Water Depth CCSW1 > 600mm",
+                "filter": [
+                  "==",
+                  "_symbol",
+                  3
+                ],
+                "minzoom": 4.7597,
+                "layout": {},
+                "paint": {
+                  "fill-color": "#CCCCCC",
+                  "fill-opacity": 0
+                }
+              }
+            ]
           }
         },
         {
@@ -710,6 +884,93 @@
               {
                 "text": "Up to 200mm",
                 "icon": "light blue"
+              }
+            ]
+          },
+          "styleOverride": {
+            "version": 8,
+            "sprite": "../sprites/sprite",
+            "glyphs": "../fonts/{fontstack}/{range}.pbf",
+            "sources": {
+              "esri": {
+                "type": "vector",
+                "bounds": [
+                  -6.98424,
+                  49.8816,
+                  2.07311,
+                  55.8115
+                ],
+                "minzoom": 1,
+                "maxzoom": 14,
+                "scheme": "xyz",
+                "url": "../../"
+              }
+            },
+            "layers": [
+              {
+                "id": "Risk of Flooding from Surface Water Depth CCSW1 > 900mm/High/1",
+                "type": "fill",
+                "source": "esri",
+                "source-layer": "Risk of Flooding from Surface Water Depth CCSW1 > 900mm",
+                "filter": [
+                  "==",
+                  "_symbol",
+                  0
+                ],
+                "minzoom": 4.7597,
+                "layout": {},
+                "paint": {
+                  "fill-color": "#555C9D"
+                }
+              },
+              {
+                "id": "Risk of Flooding from Surface Water Depth CCSW1 > 900mm/Medium/1",
+                "type": "fill",
+                "source": "esri",
+                "source-layer": "Risk of Flooding from Surface Water Depth CCSW1 > 900mm",
+                "filter": [
+                  "==",
+                  "_symbol",
+                  1
+                ],
+                "minzoom": 4.7597,
+                "layout": {},
+                "paint": {
+                  "fill-color": "#9AA0DE"
+                }
+              },
+              {
+                "id": "Risk of Flooding from Surface Water Depth CCSW1 > 900mm/Low/1",
+                "type": "fill",
+                "source": "esri",
+                "source-layer": "Risk of Flooding from Surface Water Depth CCSW1 > 900mm",
+                "filter": [
+                  "==",
+                  "_symbol",
+                  2
+                ],
+                "minzoom": 4.7597,
+                "layout": {},
+                "paint": {
+                  "fill-color": "#C4E1FF"
+                }
+              },
+              {
+                "id": "Risk of Flooding from Surface Water Depth CCSW1 > 900mm/Very low/1",
+                "type": "fill",
+                "source": "esri",
+                "source-layer": "Risk of Flooding from Surface Water Depth CCSW1 > 900mm",
+                "filter": [
+                  "==",
+                  "_symbol",
+                  3
+                ],
+                "minzoom": 4.7597,
+                "layout": {},
+                "paint": {
+                  "fill-color": "#CCCCCC",
+                  "fill-opacity": 0
+                }
               }
             ]
           }

--- a/server/models/definition/P01/maps.json
+++ b/server/models/definition/P01/maps.json
@@ -429,6 +429,93 @@
                 "icon": "light blue"
               }
             ]
+          },
+          "styleOverride": {
+            "version": 8,
+            "sprite": "../sprites/sprite",
+            "glyphs": "../fonts/{fontstack}/{range}.pbf",
+            "sources": {
+              "esri": {
+                "type": "vector",
+                "bounds": [
+                  -6.98424,
+                  49.8816,
+                  2.07311,
+                  55.8115
+                ],
+                "minzoom": 1,
+                "maxzoom": 14,
+                "scheme": "xyz",
+                "url": "../../"
+              }
+            },
+            "layers": [
+              {
+                "id": "Risk of Flooding from Surface Water Depth > 200mm/High/1",
+                "type": "fill",
+                "source": "esri",
+                "source-layer": "Risk of Flooding from Surface Water Depth > 200mm",
+                "filter": [
+                  "==",
+                  "_symbol",
+                  0
+                ],
+                "minzoom": 4.7597,
+                "layout": {},
+                "paint": {
+                  "fill-color": "#555C9D"
+                }
+              },
+              {
+                "id": "Risk of Flooding from Surface Water Depth > 200mm/Medium/1",
+                "type": "fill",
+                "source": "esri",
+                "source-layer": "Risk of Flooding from Surface Water Depth > 200mm",
+                "filter": [
+                  "==",
+                  "_symbol",
+                  1
+                ],
+                "minzoom": 4.7597,
+                "layout": {},
+                "paint": {
+                  "fill-color": "#9AA0DE"
+                }
+              },
+              {
+                "id": "Risk of Flooding from Surface Water Depth > 200mm/Low/1",
+                "type": "fill",
+                "source": "esri",
+                "source-layer": "Risk of Flooding from Surface Water Depth > 200mm",
+                "filter": [
+                  "==",
+                  "_symbol",
+                  2
+                ],
+                "minzoom": 4.7597,
+                "layout": {},
+                "paint": {
+                  "fill-color": "#C4E1FF"
+                }
+              },
+              {
+                "id": "Risk of Flooding from Surface Water Depth > 200mm/Very low/1",
+                "type": "fill",
+                "source": "esri",
+                "source-layer": "Risk of Flooding from Surface Water Depth > 200mm",
+                "filter": [
+                  "==",
+                  "_symbol",
+                  3
+                ],
+                "minzoom": 4.7597,
+                "layout": {},
+                "paint": {
+                  "fill-color": "#CCCCCC",
+                  "fill-opacity": 0
+                }
+              }
+            ]
           }
         },
         {
@@ -455,6 +542,93 @@
               {
                 "text": "Up to 200mm",
                 "icon": "light blue"
+              }
+            ]
+          },
+          "styleOverride": {
+            "version": 8,
+            "sprite": "../sprites/sprite",
+            "glyphs": "../fonts/{fontstack}/{range}.pbf",
+            "sources": {
+              "esri": {
+                "type": "vector",
+                "bounds": [
+                  -6.98424,
+                  49.8816,
+                  2.07311,
+                  55.8115
+                ],
+                "minzoom": 1,
+                "maxzoom": 14,
+                "scheme": "xyz",
+                "url": "../../"
+              }
+            },
+            "layers": [
+              {
+                "id": "Risk of Flooding from Surface Water Depth > 300mm/High/1",
+                "type": "fill",
+                "source": "esri",
+                "source-layer": "Risk of Flooding from Surface Water Depth > 300mm",
+                "filter": [
+                  "==",
+                  "_symbol",
+                  0
+                ],
+                "minzoom": 4.7597,
+                "layout": {},
+                "paint": {
+                  "fill-color": "#555C9D"
+                }
+              },
+              {
+                "id": "Risk of Flooding from Surface Water Depth > 300mm/Medium/1",
+                "type": "fill",
+                "source": "esri",
+                "source-layer": "Risk of Flooding from Surface Water Depth > 300mm",
+                "filter": [
+                  "==",
+                  "_symbol",
+                  1
+                ],
+                "minzoom": 4.7597,
+                "layout": {},
+                "paint": {
+                  "fill-color": "#9AA0DE"
+                }
+              },
+              {
+                "id": "Risk of Flooding from Surface Water Depth > 300mm/Low/1",
+                "type": "fill",
+                "source": "esri",
+                "source-layer": "Risk of Flooding from Surface Water Depth > 300mm",
+                "filter": [
+                  "==",
+                  "_symbol",
+                  2
+                ],
+                "minzoom": 4.7597,
+                "layout": {},
+                "paint": {
+                  "fill-color": "#C4E1FF"
+                }
+              },
+              {
+                "id": "Risk of Flooding from Surface Water Depth > 300mm/Very low/1",
+                "type": "fill",
+                "source": "esri",
+                "source-layer": "Risk of Flooding from Surface Water Depth > 300mm",
+                "filter": [
+                  "==",
+                  "_symbol",
+                  3
+                ],
+                "minzoom": 4.7597,
+                "layout": {},
+                "paint": {
+                  "fill-color": "#CCCCCC",
+                  "fill-opacity": 0
+                }
               }
             ]
           }
@@ -485,6 +659,93 @@
                 "icon": "light blue"
               }
             ]
+          },
+          "styleOverride": {
+            "version": 8,
+            "sprite": "../sprites/sprite",
+            "glyphs": "../fonts/{fontstack}/{range}.pbf",
+            "sources": {
+              "esri": {
+                "type": "vector",
+                "bounds": [
+                  -6.98424,
+                  49.8816,
+                  2.07311,
+                  55.8115
+                ],
+                "minzoom": 1,
+                "maxzoom": 14,
+                "scheme": "xyz",
+                "url": "../../"
+              }
+            },
+            "layers": [
+              {
+                "id": "Risk of Flooding from Surface Water Depth > 600mm/High/1",
+                "type": "fill",
+                "source": "esri",
+                "source-layer": "Risk of Flooding from Surface Water Depth > 600mm",
+                "filter": [
+                  "==",
+                  "_symbol",
+                  0
+                ],
+                "minzoom": 4.7597,
+                "layout": {},
+                "paint": {
+                  "fill-color": "#555C9D"
+                }
+              },
+              {
+                "id": "Risk of Flooding from Surface Water Depth > 600mm/Medium/1",
+                "type": "fill",
+                "source": "esri",
+                "source-layer": "Risk of Flooding from Surface Water Depth > 600mm",
+                "filter": [
+                  "==",
+                  "_symbol",
+                  1
+                ],
+                "minzoom": 4.7597,
+                "layout": {},
+                "paint": {
+                  "fill-color": "#9AA0DE"
+                }
+              },
+              {
+                "id": "Risk of Flooding from Surface Water Depth > 600mm/Low/1",
+                "type": "fill",
+                "source": "esri",
+                "source-layer": "Risk of Flooding from Surface Water Depth > 600mm",
+                "filter": [
+                  "==",
+                  "_symbol",
+                  2
+                ],
+                "minzoom": 4.7597,
+                "layout": {},
+                "paint": {
+                  "fill-color": "#C4E1FF"
+                }
+              },
+              {
+                "id": "Risk of Flooding from Surface Water Depth > 600mm/Very low/1",
+                "type": "fill",
+                "source": "esri",
+                "source-layer": "Risk of Flooding from Surface Water Depth > 600mm",
+                "filter": [
+                  "==",
+                  "_symbol",
+                  3
+                ],
+                "minzoom": 4.7597,
+                "layout": {},
+                "paint": {
+                  "fill-color": "#CCCCCC",
+                  "fill-opacity": 0
+                }
+              }
+            ]
           }
         },
         {
@@ -511,6 +772,93 @@
               {
                 "text": "Up to 200mm",
                 "icon": "light blue"
+              }
+            ]
+          },
+          "styleOverride": {
+            "version": 8,
+            "sprite": "../sprites/sprite",
+            "glyphs": "../fonts/{fontstack}/{range}.pbf",
+            "sources": {
+              "esri": {
+                "type": "vector",
+                "bounds": [
+                  -6.98424,
+                  49.8816,
+                  2.07311,
+                  55.8115
+                ],
+                "minzoom": 1,
+                "maxzoom": 14,
+                "scheme": "xyz",
+                "url": "../../"
+              }
+            },
+            "layers": [
+              {
+                "id": "Risk of Flooding from Surface Water Depth > 900mm/High/1",
+                "type": "fill",
+                "source": "esri",
+                "source-layer": "Risk of Flooding from Surface Water Depth > 900mm",
+                "filter": [
+                  "==",
+                  "_symbol",
+                  0
+                ],
+                "minzoom": 4.7597,
+                "layout": {},
+                "paint": {
+                  "fill-color": "#555C9D"
+                }
+              },
+              {
+                "id": "Risk of Flooding from Surface Water Depth > 900mm/Medium/1",
+                "type": "fill",
+                "source": "esri",
+                "source-layer": "Risk of Flooding from Surface Water Depth > 900mm",
+                "filter": [
+                  "==",
+                  "_symbol",
+                  1
+                ],
+                "minzoom": 4.7597,
+                "layout": {},
+                "paint": {
+                  "fill-color": "#9AA0DE"
+                }
+              },
+              {
+                "id": "Risk of Flooding from Surface Water Depth > 900mm/Low/1",
+                "type": "fill",
+                "source": "esri",
+                "source-layer": "Risk of Flooding from Surface Water Depth > 900mm",
+                "filter": [
+                  "==",
+                  "_symbol",
+                  2
+                ],
+                "minzoom": 4.7597,
+                "layout": {},
+                "paint": {
+                  "fill-color": "#C4E1FF"
+                }
+              },
+              {
+                "id": "Risk of Flooding from Surface Water Depth > 900mm/Very low/1",
+                "type": "fill",
+                "source": "esri",
+                "source-layer": "Risk of Flooding from Surface Water Depth > 900mm",
+                "filter": [
+                  "==",
+                  "_symbol",
+                  3
+                ],
+                "minzoom": 4.7597,
+                "layout": {},
+                "paint": {
+                  "fill-color": "#CCCCCC",
+                  "fill-opacity": 0
+                }
               }
             ]
           }
@@ -541,6 +889,93 @@
                 "icon": "light blue"
               }
             ]
+          },
+          "styleOverride": {
+            "version": 8,
+            "sprite": "../sprites/sprite",
+            "glyphs": "../fonts/{fontstack}/{range}.pbf",
+            "sources": {
+              "esri": {
+                "type": "vector",
+                "bounds": [
+                  -6.98424,
+                  49.8816,
+                  2.07311,
+                  55.8115
+                ],
+                "minzoom": 1,
+                "maxzoom": 14,
+                "scheme": "xyz",
+                "url": "../../"
+              }
+            },
+            "layers": [
+              {
+                "id": "Risk of Flooding from Surface Water Depth CCSW1 > 200mm/High/1",
+                "type": "fill",
+                "source": "esri",
+                "source-layer": "Risk of Flooding from Surface Water Depth CCSW1 > 200mm",
+                "filter": [
+                  "==",
+                  "_symbol",
+                  0
+                ],
+                "minzoom": 4.7597,
+                "layout": {},
+                "paint": {
+                  "fill-color": "#555C9D"
+                }
+              },
+              {
+                "id": "Risk of Flooding from Surface Water Depth CCSW1 > 200mm/Medium/1",
+                "type": "fill",
+                "source": "esri",
+                "source-layer": "Risk of Flooding from Surface Water Depth CCSW1 > 200mm",
+                "filter": [
+                  "==",
+                  "_symbol",
+                  1
+                ],
+                "minzoom": 4.7597,
+                "layout": {},
+                "paint": {
+                  "fill-color": "#9AA0DE"
+                }
+              },
+              {
+                "id": "Risk of Flooding from Surface Water Depth CCSW1 > 200mm/Low/1",
+                "type": "fill",
+                "source": "esri",
+                "source-layer": "Risk of Flooding from Surface Water Depth CCSW1 > 200mm",
+                "filter": [
+                  "==",
+                  "_symbol",
+                  2
+                ],
+                "minzoom": 4.7597,
+                "layout": {},
+                "paint": {
+                  "fill-color": "#C4E1FF"
+                }
+              },
+              {
+                "id": "Risk of Flooding from Surface Water Depth CCSW1 > 200mm/Very low/1",
+                "type": "fill",
+                "source": "esri",
+                "source-layer": "Risk of Flooding from Surface Water Depth CCSW1 > 200mm",
+                "filter": [
+                  "==",
+                  "_symbol",
+                  3
+                ],
+                "minzoom": 4.7597,
+                "layout": {},
+                "paint": {
+                  "fill-color": "#CCCCCC",
+                  "fill-opacity": 0
+                }
+              }
+            ]
           }
         },
         {
@@ -567,6 +1002,93 @@
               {
                 "text": "Up to 200mm",
                 "icon": "light blue"
+              }
+            ]
+          },
+          "styleOverride": {
+            "version": 8,
+            "sprite": "../sprites/sprite",
+            "glyphs": "../fonts/{fontstack}/{range}.pbf",
+            "sources": {
+              "esri": {
+                "type": "vector",
+                "bounds": [
+                  -6.98424,
+                  49.8816,
+                  2.07311,
+                  55.8115
+                ],
+                "minzoom": 1,
+                "maxzoom": 14,
+                "scheme": "xyz",
+                "url": "../../"
+              }
+            },
+            "layers": [
+              {
+                "id": "Risk of Flooding from Surface Water Depth CCSW1 > 300mm/High/1",
+                "type": "fill",
+                "source": "esri",
+                "source-layer": "Risk of Flooding from Surface Water Depth CCSW1 > 300mm",
+                "filter": [
+                  "==",
+                  "_symbol",
+                  0
+                ],
+                "minzoom": 4.7597,
+                "layout": {},
+                "paint": {
+                  "fill-color": "#555C9D"
+                }
+              },
+              {
+                "id": "Risk of Flooding from Surface Water Depth CCSW1 > 300mm/Medium/1",
+                "type": "fill",
+                "source": "esri",
+                "source-layer": "Risk of Flooding from Surface Water Depth CCSW1 > 300mm",
+                "filter": [
+                  "==",
+                  "_symbol",
+                  1
+                ],
+                "minzoom": 4.7597,
+                "layout": {},
+                "paint": {
+                  "fill-color": "#9AA0DE"
+                }
+              },
+              {
+                "id": "Risk of Flooding from Surface Water Depth CCSW1 > 300mm/Low/1",
+                "type": "fill",
+                "source": "esri",
+                "source-layer": "Risk of Flooding from Surface Water Depth CCSW1 > 300mm",
+                "filter": [
+                  "==",
+                  "_symbol",
+                  2
+                ],
+                "minzoom": 4.7597,
+                "layout": {},
+                "paint": {
+                  "fill-color": "#C4E1FF"
+                }
+              },
+              {
+                "id": "Risk of Flooding from Surface Water Depth CCSW1 > 300mm/Very low/1",
+                "type": "fill",
+                "source": "esri",
+                "source-layer": "Risk of Flooding from Surface Water Depth CCSW1 > 300mm",
+                "filter": [
+                  "==",
+                  "_symbol",
+                  3
+                ],
+                "minzoom": 4.7597,
+                "layout": {},
+                "paint": {
+                  "fill-color": "#CCCCCC",
+                  "fill-opacity": 0
+                }
               }
             ]
           }
@@ -597,6 +1119,93 @@
                 "icon": "light blue"
               }
             ]
+          },
+          "styleOverride": {
+            "version": 8,
+            "sprite": "../sprites/sprite",
+            "glyphs": "../fonts/{fontstack}/{range}.pbf",
+            "sources": {
+              "esri": {
+                "type": "vector",
+                "bounds": [
+                  -6.98424,
+                  49.8816,
+                  2.07311,
+                  55.8115
+                ],
+                "minzoom": 1,
+                "maxzoom": 14,
+                "scheme": "xyz",
+                "url": "../../"
+              }
+            },
+            "layers": [
+              {
+                "id": "Risk of Flooding from Surface Water Depth CCSW1 > 600mm/High/1",
+                "type": "fill",
+                "source": "esri",
+                "source-layer": "Risk of Flooding from Surface Water Depth CCSW1 > 600mm",
+                "filter": [
+                  "==",
+                  "_symbol",
+                  0
+                ],
+                "minzoom": 4.7597,
+                "layout": {},
+                "paint": {
+                  "fill-color": "#555C9D"
+                }
+              },
+              {
+                "id": "Risk of Flooding from Surface Water Depth CCSW1 > 600mm/Medium/1",
+                "type": "fill",
+                "source": "esri",
+                "source-layer": "Risk of Flooding from Surface Water Depth CCSW1 > 600mm",
+                "filter": [
+                  "==",
+                  "_symbol",
+                  1
+                ],
+                "minzoom": 4.7597,
+                "layout": {},
+                "paint": {
+                  "fill-color": "#9AA0DE"
+                }
+              },
+              {
+                "id": "Risk of Flooding from Surface Water Depth CCSW1 > 600mm/Low/1",
+                "type": "fill",
+                "source": "esri",
+                "source-layer": "Risk of Flooding from Surface Water Depth CCSW1 > 600mm",
+                "filter": [
+                  "==",
+                  "_symbol",
+                  2
+                ],
+                "minzoom": 4.7597,
+                "layout": {},
+                "paint": {
+                  "fill-color": "#C4E1FF"
+                }
+              },
+              {
+                "id": "Risk of Flooding from Surface Water Depth CCSW1 > 600mm/Very low/1",
+                "type": "fill",
+                "source": "esri",
+                "source-layer": "Risk of Flooding from Surface Water Depth CCSW1 > 600mm",
+                "filter": [
+                  "==",
+                  "_symbol",
+                  3
+                ],
+                "minzoom": 4.7597,
+                "layout": {},
+                "paint": {
+                  "fill-color": "#CCCCCC",
+                  "fill-opacity": 0
+                }
+              }
+            ]
           }
         },
         {
@@ -623,6 +1232,93 @@
               {
                 "text": "Up to 200mm",
                 "icon": "light blue"
+              }
+            ]
+          },
+          "styleOverride": {
+            "version": 8,
+            "sprite": "../sprites/sprite",
+            "glyphs": "../fonts/{fontstack}/{range}.pbf",
+            "sources": {
+              "esri": {
+                "type": "vector",
+                "bounds": [
+                  -6.98424,
+                  49.8816,
+                  2.07311,
+                  55.8115
+                ],
+                "minzoom": 1,
+                "maxzoom": 14,
+                "scheme": "xyz",
+                "url": "../../"
+              }
+            },
+            "layers": [
+              {
+                "id": "Risk of Flooding from Surface Water Depth CCSW1 > 900mm/High/1",
+                "type": "fill",
+                "source": "esri",
+                "source-layer": "Risk of Flooding from Surface Water Depth CCSW1 > 900mm",
+                "filter": [
+                  "==",
+                  "_symbol",
+                  0
+                ],
+                "minzoom": 4.7597,
+                "layout": {},
+                "paint": {
+                  "fill-color": "#555C9D"
+                }
+              },
+              {
+                "id": "Risk of Flooding from Surface Water Depth CCSW1 > 900mm/Medium/1",
+                "type": "fill",
+                "source": "esri",
+                "source-layer": "Risk of Flooding from Surface Water Depth CCSW1 > 900mm",
+                "filter": [
+                  "==",
+                  "_symbol",
+                  1
+                ],
+                "minzoom": 4.7597,
+                "layout": {},
+                "paint": {
+                  "fill-color": "#9AA0DE"
+                }
+              },
+              {
+                "id": "Risk of Flooding from Surface Water Depth CCSW1 > 900mm/Low/1",
+                "type": "fill",
+                "source": "esri",
+                "source-layer": "Risk of Flooding from Surface Water Depth CCSW1 > 900mm",
+                "filter": [
+                  "==",
+                  "_symbol",
+                  2
+                ],
+                "minzoom": 4.7597,
+                "layout": {},
+                "paint": {
+                  "fill-color": "#C4E1FF"
+                }
+              },
+              {
+                "id": "Risk of Flooding from Surface Water Depth CCSW1 > 900mm/Very low/1",
+                "type": "fill",
+                "source": "esri",
+                "source-layer": "Risk of Flooding from Surface Water Depth CCSW1 > 900mm",
+                "filter": [
+                  "==",
+                  "_symbol",
+                  3
+                ],
+                "minzoom": 4.7597,
+                "layout": {},
+                "paint": {
+                  "fill-color": "#CCCCCC",
+                  "fill-opacity": 0
+                }
               }
             ]
           }

--- a/server/src/js/map-page/map-page.js
+++ b/server/src/js/map-page/map-page.js
@@ -77,16 +77,18 @@ function mapPage () {
   const observer = new MutationObserver((mutations) => {
     mutations.forEach(() => {
       const mapContainer = document.querySelector('.esri-view-surface')
-      if (mapContainer?.getAttribute('tabindex') !== '5') {
+      if (mapContainer && (mapContainer.getAttribute('tabindex') !== '5')) {
         mapContainer.setAttribute('tabindex', '5')
       }
       const esriLink = document.querySelector('.esri-attribution__link')
-      if (esriLink?.getAttribute('tabindex') !== '12') {
-        esriLink.setAttribute('tabindex', '12')
-      }
-      // Removes target attribute from esri link
-      if (esriLink?.hasAttribute('target')) {
-        esriLink.removeAttribute('target')
+      if (esriLink) {
+        if (esriLink?.getAttribute('tabindex') !== '12') {
+          esriLink.setAttribute('tabindex', '12')
+        }
+        // Removes target attribute from esri link
+        if (esriLink?.hasAttribute('target')) {
+          esriLink.removeAttribute('target')
+        }
       }
 
       // Function to update tabindex for zoom buttons within the shadow root

--- a/server/src/js/map.js
+++ b/server/src/js/map.js
@@ -119,33 +119,13 @@ function createFeatureLayers (layers) {
           url: featureMap.url,
           apiKey: window.mapConfig.mapToken,
           opacity: 0.5,
-          visible: false,
-          renderer: {
-            type: "unique-value",
-            field: "TYPE",
-            uniqueValueInfos: {
-              "value": 'value',
-              "symbol": {
-                "fill-color": '#FF0000',
-                "type": "simple-fill",
-                "style": "solid",
-                "outline": {
-                  "style": "none"
-                }
-              },
-              "label": 'value'
-            }
-          }
+          visible: false
         })
-        console.log('featureMap.styleOverride', featureMap.styleOverride)
         if (featureMap.styleOverride) {
-          console.log('in override')
-          console.log('vectorTileLayer: ', vectorTileLayer.currentStyleInfo)
-          console.log('after')
-
-          // vectorTileLayer.loadStyle(featureMap.styleOverride)
-          console.log('vectorTileLayer: ', vectorTileLayer)
-          console.log('vectorTileLayer: ', vectorTileLayer.opacity)
+          vectorTileLayer.load().then((vl) => {
+            // console.log('loaded vectorTileLayer: ', vl.currentStyleInfo)
+            vl.currentStyleInfo.style = featureMap.styleOverride
+          })
         }
         layers.push(vectorTileLayer)
       }

--- a/server/src/js/map.js
+++ b/server/src/js/map.js
@@ -114,13 +114,40 @@ function createFeatureLayers (layers) {
     const maps = layer.maps
     for (const featureMap of maps) {
       if (featureMap.url) {
-        layers.push(new VectorTileLayer({
+        const vectorTileLayer = new VectorTileLayer({
           id: featureMap.ref,
           url: featureMap.url,
           apiKey: window.mapConfig.mapToken,
-          opacity: window.mapConfig.mapTransparency,
-          visible: false
-        }))
+          opacity: 0.5,
+          visible: false,
+          renderer: {
+            type: "unique-value",
+            field: "TYPE",
+            uniqueValueInfos: {
+              "value": 'value',
+              "symbol": {
+                "fill-color": '#FF0000',
+                "type": "simple-fill",
+                "style": "solid",
+                "outline": {
+                  "style": "none"
+                }
+              },
+              "label": 'value'
+            }
+          }
+        })
+        console.log('featureMap.styleOverride', featureMap.styleOverride)
+        if (featureMap.styleOverride) {
+          console.log('in override')
+          console.log('vectorTileLayer: ', vectorTileLayer.currentStyleInfo)
+          console.log('after')
+
+          // vectorTileLayer.loadStyle(featureMap.styleOverride)
+          console.log('vectorTileLayer: ', vectorTileLayer)
+          console.log('vectorTileLayer: ', vectorTileLayer.opacity)
+        }
+        layers.push(vectorTileLayer)
       }
     }
   }

--- a/server/src/js/map.js
+++ b/server/src/js/map.js
@@ -123,7 +123,6 @@ function createFeatureLayers (layers) {
         })
         if (featureMap.styleOverride) {
           vectorTileLayer.load().then((vl) => {
-            // console.log('loaded vectorTileLayer: ', vl.currentStyleInfo)
             vl.currentStyleInfo.style = featureMap.styleOverride
           })
         }

--- a/server/src/js/map.js
+++ b/server/src/js/map.js
@@ -118,7 +118,7 @@ function createFeatureLayers (layers) {
           id: featureMap.ref,
           url: featureMap.url,
           apiKey: window.mapConfig.mapToken,
-          opacity: 0.5,
+          opacity: window.mapConfig.mapTransparency,
           visible: false
         })
         if (featureMap.styleOverride) {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/LTFRI-1784

the very low category on the depth extents for surface water should be removed.