### PR TITLE
GOV.UK frontend v5.8.0 update

### DIFF
--- a/client/sass/application.scss
+++ b/client/sass/application.scss
@@ -1,6 +1,6 @@
 $govuk-assets-path: '/assets/';
 
-@import "govuk-frontend/dist/govuk/all";
+@import "govuk-frontend/dist/govuk/index";
 @import "./depth-gauges";
 @import "./risk-page";
 @import "./risk-data";

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "blipp": "4.0.2",
         "dotenv": "^16.4.5",
         "friendly-challenge": "^0.9.12",
-        "govuk-frontend": "^5.2.0",
+        "govuk-frontend": "^5.8.0",
         "hapi-pino": "^12.0.0",
         "hapi-rate-limit": "^7.0.0",
         "https-proxy-agent": "^7.0.0",
@@ -5682,7 +5682,6 @@
       "version": "5.8.0",
       "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.8.0.tgz",
       "integrity": "sha512-6l3f/YhDUCWjpmSW3CL95Hg8B+ZLzTf2WYo25ZtCs2Lb8UIzxxxFI8LxG7Ey/z04UuPhUunqFhTwSkQyJ69XbQ==",
-      "license": "MIT",
       "engines": {
         "node": ">= 4.2.0"
       }

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "blipp": "4.0.2",
     "dotenv": "^16.4.5",
     "friendly-challenge": "^0.9.12",
-    "govuk-frontend": "^5.2.0",
+    "govuk-frontend": "^5.8.0",
     "hapi-pino": "^12.0.0",
     "hapi-rate-limit": "^7.0.0",
     "https-proxy-agent": "^7.0.0",


### PR DESCRIPTION
https://eaflood.atlassian.net/jira/software/c/projects/LTFRI/boards/589?selectedIssue=LTFRI-1407

This change implements the newest version of the GOV.UK frontend.