### PR TITLE
Fix to depth bar font size

### DIFF
--- a/client/sass/_map-controls.scss
+++ b/client/sass/_map-controls.scss
@@ -134,6 +134,7 @@ $gov-font: "HelveticaNeue", "Helvetica Neue", "Arial", "Helvetica", sans-serif;
   .scenario-heading {
     text-decoration: underline;
     text-decoration-thickness: 2px;
+    font-size: 16px;
   }
 
   .first-radio {


### PR DESCRIPTION
The sizing for the depth bar needs to be 16px, rather than dynamic fo consistent styling.