### PR TITLE
Missing Security Related HTTP Headers

### DIFF
--- a/server/plugins/cookies.js
+++ b/server/plugins/cookies.js
@@ -11,7 +11,6 @@ module.exports = {
     name: 'cookies',
     register: (server, options) => {
       server.state('cookies_policy', cookiePolicyOptions)
-
       server.ext('onPreResponse', (request, h) => {
         if (request.response.variety === 'view') {
           const { state } = request


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/LTFRI-899

HTTP response headers which could be used to enhance the security posture of the web application were not used or misconfigured.