### PR TITLE
LTFRI-2289 Change FriendlyCaptcha display to match gov.uk styling

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -22,7 +22,7 @@ jobs:
           node-version: '22.x'
       - name: Run unit tests
         run: |
-          npm ci
+          npm ci --ignore-scripts
           npm run test
           sed -i 's/\/home\/runner\/work\/cyltfr-app\/cyltfr-app\//\/github\/workspace\//g' test/output/lcov.info
       - name: SonarCloud Scan

--- a/client/sass/application.scss
+++ b/client/sass/application.scss
@@ -32,6 +32,10 @@ $govuk-assets-path: '/assets/';
   float: right;
 }
 
+.do-not-display {
+  display: none;
+}
+
 #postcode > dd {
   margin-inline-start: 0;
 }

--- a/client/sass/application.scss
+++ b/client/sass/application.scss
@@ -32,10 +32,6 @@ $govuk-assets-path: '/assets/';
   float: right;
 }
 
-.do-not-display {
-  display: none;
-}
-
 #postcode > dd {
   margin-inline-start: 0;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
         "eslint": "^9.39.4",
         "husky": "^9.1.7",
         "jest": "^30.3.0",
+        "jest-environment-jsdom": "^30.3.0",
         "lint-staged": "^16.4.0",
         "neostandard": "^0.13.0",
         "nodemon": "^3.1.14",
@@ -156,6 +157,27 @@
       "dependencies": {
         "tslib": "^2.8.1"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
@@ -683,6 +705,123 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@discoveryjs/json-ext": {
       "version": "0.6.3",
@@ -1793,6 +1932,34 @@
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/environment-jsdom-abstract": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/environment-jsdom-abstract/-/environment-jsdom-abstract-30.3.0.tgz",
+      "integrity": "sha512-0hNFs5N6We3DMCwobzI0ydhkY10sT1tZSC0AAiy+0g2Dt/qEWgrcV5BrMxPczhe41cxW4qm6X+jqZaUdpZIajA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "30.3.0",
+        "@jest/fake-timers": "30.3.0",
+        "@jest/types": "30.3.0",
+        "@types/jsdom": "^21.1.7",
+        "@types/node": "*",
+        "jest-mock": "30.3.0",
+        "jest-util": "30.3.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
       }
     },
     "node_modules/@jest/expect": {
@@ -2967,6 +3134,18 @@
       "license": "MIT",
       "dependencies": {
         "@types/istanbul-lib-report": "*"
+      }
+    },
+    "node_modules/@types/jsdom": {
+      "version": "21.1.7",
+      "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-21.1.7.tgz",
+      "integrity": "sha512-yOriVnggzrnQ3a9OKOCxaVuSug3w3/SbOj5i7VwXWZEyUNl3bLF9V3MfxGbZKuwqJOQyRfqXyROBB1CoZLFWzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/tough-cookie": "*",
+        "parse5": "^7.0.0"
       }
     },
     "node_modules/@types/json-schema": {
@@ -5269,6 +5448,20 @@
       "integrity": "sha512-FAaLDaplstoRsDR8XGYH51znUN0UY7nMc6Z9/fvE8EXGwvJE9hu7W2vHwx1+bd6gCYnln9nLbzxFTrcO9YQDZw==",
       "license": "MIT"
     },
+    "node_modules/cssstyle": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
@@ -5796,6 +5989,57 @@
         "node": ">= 12"
       }
     },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/data-urls/node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/data-urls/node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
@@ -5866,6 +6110,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/dedent": {
       "version": "1.7.2",
@@ -6117,6 +6368,19 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/envinfo": {
@@ -7484,12 +7748,39 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
     },
     "node_modules/https-proxy-agent": {
       "version": "7.0.6",
@@ -8033,6 +8324,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-regex": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -8523,6 +8821,29 @@
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
+    "node_modules/jest-environment-jsdom": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-30.3.0.tgz",
+      "integrity": "sha512-RLEOJy6ip1lpw0yqJ8tB3i88FC7VBz7i00Zvl2qF71IdxjS98gC9/0SPWYIBVXHm5hgCYK0PAlSlnHGGy9RoMg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "30.3.0",
+        "@jest/environment-jsdom-abstract": "30.3.0",
+        "jsdom": "^26.1.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/jest-environment-node": {
       "version": "30.3.0",
       "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-30.3.0.tgz",
@@ -8941,6 +9262,84 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "26.1.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz",
+      "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "cssstyle": "^4.2.1",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.5.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.16",
+        "parse5": "^7.2.1",
+        "rrweb-cssom": "^0.8.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^5.1.1",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.1.1",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/jsdom/node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/jsdom/node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/jsesc": {
@@ -9952,6 +10351,13 @@
         "node": ">= 6"
       }
     },
+    "node_modules/nwsapi": {
+      "version": "2.2.23",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.23.tgz",
+      "integrity": "sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -10231,6 +10637,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
     "node_modules/path-exists": {
@@ -11002,6 +11421,13 @@
       "integrity": "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==",
       "license": "Unlicense"
     },
+    "node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/rw": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
@@ -11156,6 +11582,19 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=11.0.0"
+      }
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
       }
     },
     "node_modules/schema-utils": {
@@ -11893,6 +12332,13 @@
       "integrity": "sha512-djbJ/vZKZO+gPoSDThGNpKDO+o+bAeA4XQKovvkNCqnIS2t+S4qnLAGQhyyrulhCFRl1WWzAp0wUDV8PpTVU3g==",
       "license": "ISC"
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/synckit": {
       "version": "0.11.12",
       "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.12.tgz",
@@ -12134,6 +12580,26 @@
       "integrity": "sha512-ppJZNDuKGgxzkHihX8v9v9G5f+18gzaTfrukGrq6ueg0lmH4nqVnA2IPG0AEH3jKEk2GRJCUhDoqpoiw3PHLBA==",
       "license": "ISC"
     },
+    "node_modules/tldts": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^6.1.86"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tmpl": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
@@ -12162,6 +12628,19 @@
       "license": "ISC",
       "bin": {
         "nodetouch": "bin/nodetouch.js"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^6.1.32"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/tr46": {
@@ -12527,6 +13006,19 @@
         "node": ">=10.12.0"
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/walker": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.8.tgz",
@@ -12727,6 +13219,30 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=4.0"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/whatwg-url": {
@@ -12976,6 +13492,45 @@
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
+    },
+    "node_modules/ws": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/xmldoc": {
       "version": "2.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@airbrake/node": "^2.1.9",
         "@arcgis/core": "^4.34.8",
         "@esri/arcgis-rest-request": "^4.10.2",
-        "@friendlycaptcha/sdk": "^0.1.37",
+        "@friendlycaptcha/sdk": "^0.2.0",
         "@hapi/boom": "^10.0.1",
         "@hapi/catbox-memory": "^6.0.2",
         "@hapi/catbox-redis": "7.0.2",
@@ -1039,9 +1039,9 @@
       "license": "MIT"
     },
     "node_modules/@friendlycaptcha/sdk": {
-      "version": "0.1.37",
-      "resolved": "https://registry.npmjs.org/@friendlycaptcha/sdk/-/sdk-0.1.37.tgz",
-      "integrity": "sha512-A3XPZgNTWC2WioxbhAGeXKtwZZorwQutMeuNVxgdxT7eMWqxOZiu8xDUoOqRBoR8O2bXuIJR+MBffhVpp4zTjQ==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@friendlycaptcha/sdk/-/sdk-0.2.1.tgz",
+      "integrity": "sha512-pRlaIRO9gVjwwDpFJc55KrmGhlpsIN+hRbjiLXPx70tCwOOXt73HQwySnWOfm9HSFGwLSPUZiu77c039RnWE0g==",
       "license": "MPL-2.0"
     },
     "node_modules/@hapi/accept": {
@@ -12632,6 +12632,7 @@
       "integrity": "sha512-MfwFQ6SfwinsUVi0rNJm7rHZ31GyTcpVE5pgVA3hwFRb7COD4TzjUUwhGWKfO50+xdc2MQPuEBBJoqIMGt3JDw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@discoveryjs/json-ext": "^0.6.1",
         "@webpack-cli/configtest": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@airbrake/node": "^2.1.9",
     "@arcgis/core": "^4.34.8",
     "@esri/arcgis-rest-request": "^4.10.2",
-    "@friendlycaptcha/sdk": "^0.1.37",
+    "@friendlycaptcha/sdk": "^0.2.0",
     "@hapi/boom": "^10.0.1",
     "@hapi/catbox-memory": "^6.0.2",
     "@hapi/catbox-redis": "7.0.2",

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "eslint": "^9.39.4",
     "husky": "^9.1.7",
     "jest": "^30.3.0",
+    "jest-environment-jsdom": "^30.3.0",
     "lint-staged": "^16.4.0",
     "neostandard": "^0.13.0",
     "nodemon": "^3.1.14",
@@ -87,7 +88,8 @@
     "collectCoverage": true,
     "collectCoverageFrom": [
       "server/**/*.js",
-      "!server/public/**/*",
+      "!server/public/build/**/*",
+      "!server/public/static/js/vendor/*",
       "!server/src/js/**/*.js"
     ],
     "coverageReporters": [

--- a/server/public/static/js/__tests__/friendly-captcha-handler.spec.js
+++ b/server/public/static/js/__tests__/friendly-captcha-handler.spec.js
@@ -1,0 +1,214 @@
+/**
+ * @jest-environment jsdom
+ */
+
+const { setupCaptchaEventListeners, initRetryButton } = require('../friendly-captcha-handler')
+
+describe('setupCaptchaEventListeners', () => {
+  let mockCaptchaElement
+  let frcChecking
+  let frcComplete
+  let frcError
+  let frcErrorSummary
+  let submitButton
+  let errorSummaryElement
+
+  beforeEach(() => {
+    // Setup mock DOM
+    document.body.innerHTML = `
+      <div id="FriendlyCaptchaChecking" style="display: block;"></div>
+      <div id="FriendlyCaptchaComplete" class="do-not-display" style="display: none;"></div>
+      <div id="FriendlyCaptchaError" class="do-not-display" style="display: none;"></div>
+      <div id="FriendlyCaptchaErrorSummary" class="do-not-display" style="display: none;">
+        <div class="govuk-error-summary" tabindex="-1"></div>
+      </div>
+      <button id="post-code-button" disabled="true"></button>
+      <div id="FriendlyCaptcha" class="frc-captcha"></div>
+    `
+
+    mockCaptchaElement = document.getElementById('FriendlyCaptcha')
+    frcChecking = document.getElementById('FriendlyCaptchaChecking')
+    frcComplete = document.getElementById('FriendlyCaptchaComplete')
+    frcError = document.getElementById('FriendlyCaptchaError')
+    frcErrorSummary = document.getElementById('FriendlyCaptchaErrorSummary')
+    submitButton = document.getElementById('post-code-button')
+    errorSummaryElement = frcErrorSummary.querySelector('.govuk-error-summary')
+
+    // Mock focus method
+    errorSummaryElement.focus = jest.fn()
+
+    // Reset document title
+    document.title = 'Where do you want to check?'
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  test('should enable submit button and show complete state when captcha completes', () => {
+    setupCaptchaEventListeners(mockCaptchaElement)
+
+    const event = new CustomEvent('frc:widget.statechange', {
+      detail: { state: 'completed' }
+    })
+    mockCaptchaElement.dispatchEvent(event)
+
+    expect(frcChecking.style.display).toBe('none')
+    expect(frcComplete.style.display).toBe('block')
+    expect(submitButton.disabled).toBe(false)
+    expect(frcError.style.display).toBe('none')
+    expect(frcErrorSummary.style.display).toBe('none')
+  })
+
+  test('should show error state and disable submit button initially for other states', () => {
+    setupCaptchaEventListeners(mockCaptchaElement)
+
+    const event = new CustomEvent('frc:widget.statechange', {
+      detail: { state: 'fetching' }
+    })
+    mockCaptchaElement.dispatchEvent(event)
+
+    expect(submitButton.disabled).toBe(true)
+  })
+
+  test('should show error state and focus error summary on captcha error', () => {
+    setupCaptchaEventListeners(mockCaptchaElement)
+
+    const event = new CustomEvent('frc:widget.statechange', {
+      detail: { state: 'error' }
+    })
+    mockCaptchaElement.dispatchEvent(event)
+
+    expect(frcChecking.style.display).toBe('none')
+    expect(frcComplete.style.display).toBe('none')
+    expect(frcError.style.display).toBe('block')
+    expect(frcErrorSummary.style.display).toBe('block')
+    expect(submitButton.disabled).toBe(false)
+    expect(errorSummaryElement.focus).toHaveBeenCalled()
+  })
+
+  test('should prefix document title with "Error: " on captcha error', () => {
+    setupCaptchaEventListeners(mockCaptchaElement)
+
+    const event = new CustomEvent('frc:widget.statechange', {
+      detail: { state: 'error' }
+    })
+    mockCaptchaElement.dispatchEvent(event)
+
+    expect(document.title).toBe('Error: Where do you want to check?')
+  })
+
+  test('should not duplicate "Error: " prefix if already present', () => {
+    document.title = 'Error: Where do you want to check?'
+    setupCaptchaEventListeners(mockCaptchaElement)
+
+    const event = new CustomEvent('frc:widget.statechange', {
+      detail: { state: 'error' }
+    })
+    mockCaptchaElement.dispatchEvent(event)
+
+    expect(document.title).toBe('Error: Where do you want to check?')
+  })
+
+  test('should handle expired state same as error state', () => {
+    setupCaptchaEventListeners(mockCaptchaElement)
+
+    const event = new CustomEvent('frc:widget.statechange', {
+      detail: { state: 'expired' }
+    })
+    mockCaptchaElement.dispatchEvent(event)
+
+    expect(frcChecking.style.display).toBe('none')
+    expect(frcComplete.style.display).toBe('none')
+    expect(frcError.style.display).toBe('block')
+    expect(frcErrorSummary.style.display).toBe('block')
+    expect(submitButton.disabled).toBe(false)
+    expect(document.title).toContain('Error: ')
+    expect(errorSummaryElement.focus).toHaveBeenCalled()
+  })
+
+  test('should handle missing optional elements gracefully', () => {
+    // Remove optional elements
+    frcChecking.remove()
+    frcComplete.remove()
+    frcError.remove()
+    frcErrorSummary.remove()
+
+    setupCaptchaEventListeners(mockCaptchaElement)
+
+    const event = new CustomEvent('frc:widget.statechange', {
+      detail: { state: 'completed' }
+    })
+
+    // Should not throw error
+    expect(() => {
+      mockCaptchaElement.dispatchEvent(event)
+    }).not.toThrow()
+
+    expect(submitButton.disabled).toBe(false)
+  })
+
+  test('should disable submit button for unstarted state', () => {
+    setupCaptchaEventListeners(mockCaptchaElement)
+
+    const event = new CustomEvent('frc:widget.statechange', {
+      detail: { state: 'unstarted' }
+    })
+    mockCaptchaElement.dispatchEvent(event)
+
+    expect(submitButton.disabled).toBe(true)
+  })
+
+  test('should disable submit button for fetching state', () => {
+    setupCaptchaEventListeners(mockCaptchaElement)
+
+    const event = new CustomEvent('frc:widget.statechange', {
+      detail: { state: 'fetching' }
+    })
+    mockCaptchaElement.dispatchEvent(event)
+
+    expect(submitButton.disabled).toBe(true)
+  })
+})
+
+describe('initRetryButton', () => {
+  let retryButton
+
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <a role="button" id="FriendlyCaptchaResetButton" href="/postcode#" class="govuk-button">Retry</a>
+    `
+    retryButton = document.getElementById('FriendlyCaptchaResetButton')
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  test('should attach click handler to retry button', () => {
+    // Store the original addEventListener
+    const addEventListenerSpy = jest.spyOn(retryButton, 'addEventListener')
+
+    initRetryButton()
+
+    expect(addEventListenerSpy).toHaveBeenCalledWith('click', expect.any(Function))
+  })
+
+  test('should handle missing retry button gracefully', () => {
+    retryButton.remove()
+
+    expect(() => {
+      initRetryButton()
+    }).not.toThrow()
+  })
+
+  test('should prevent default link behavior when retry button is clicked', () => {
+    initRetryButton()
+
+    const event = new Event('click')
+    const preventDefaultSpy = jest.spyOn(event, 'preventDefault')
+    retryButton.dispatchEvent(event)
+
+    expect(preventDefaultSpy).toHaveBeenCalled()
+  })
+})

--- a/server/public/static/js/__tests__/friendly-captcha-handler.spec.js
+++ b/server/public/static/js/__tests__/friendly-captcha-handler.spec.js
@@ -16,14 +16,15 @@ describe('setupCaptchaEventListeners', () => {
   beforeEach(() => {
     // Setup mock DOM
     document.body.innerHTML = `
-      <div id="FriendlyCaptchaChecking" style="display: block;"></div>
-      <div id="FriendlyCaptchaComplete" class="do-not-display" style="display: none;"></div>
-      <div id="FriendlyCaptchaError" class="do-not-display" style="display: none;"></div>
-      <div id="FriendlyCaptchaErrorSummary" class="do-not-display" style="display: none;">
+      <div id="FriendlyCaptchaChecking" id="FriendlyCaptchaChecking" class="" role="status" aria-live="polite" aria-atomic="true"></div>
+      <div id="FriendlyCaptchaComplete" class="govuk-!-display-none" role="status" aria-live="polite" aria-atomic="true"></div>
+      <div id="FriendlyCaptchaError" class="govuk-!-display-none" role="alert" aria-live="assertive" aria-atomic="true" tabindex="-1"></div>
+      <div id="FriendlyCaptchaErrorSummary" class="govuk-!-display-none">
         <div class="govuk-error-summary" tabindex="-1"></div>
       </div>
       <button id="post-code-button" disabled="true"></button>
       <div id="FriendlyCaptcha" class="frc-captcha"></div>
+      <a role="button" id="FriendlyCaptchaResetButton" href="/postcode#">Retry</a>
     `
 
     mockCaptchaElement = document.getElementById('FriendlyCaptcha')
@@ -53,11 +54,11 @@ describe('setupCaptchaEventListeners', () => {
     })
     mockCaptchaElement.dispatchEvent(event)
 
-    expect(frcChecking.style.display).toBe('none')
-    expect(frcComplete.style.display).toBe('block')
+    expect(frcChecking.classList.contains('govuk-!-display-none')).toBeTruthy()
+    expect(frcComplete.classList.contains('govuk-!-display-none')).toBeFalsy()
     expect(submitButton.disabled).toBe(false)
-    expect(frcError.style.display).toBe('none')
-    expect(frcErrorSummary.style.display).toBe('none')
+    expect(frcError.classList.contains('govuk-!-display-none')).toBeTruthy()
+    expect(frcErrorSummary.classList.contains('govuk-!-display-none')).toBeTruthy()
   })
 
   test('should show error state and disable submit button initially for other states', () => {
@@ -79,10 +80,10 @@ describe('setupCaptchaEventListeners', () => {
     })
     mockCaptchaElement.dispatchEvent(event)
 
-    expect(frcChecking.style.display).toBe('none')
-    expect(frcComplete.style.display).toBe('none')
-    expect(frcError.style.display).toBe('block')
-    expect(frcErrorSummary.style.display).toBe('block')
+    expect(frcChecking.classList.contains('govuk-!-display-none')).toBeTruthy()
+    expect(frcComplete.classList.contains('govuk-!-display-none')).toBeTruthy()
+    expect(frcError.classList.contains('govuk-!-display-none')).toBeFalsy()
+    expect(frcErrorSummary.classList.contains('govuk-!-display-none')).toBeFalsy()
     expect(submitButton.disabled).toBe(false)
     expect(errorSummaryElement.focus).toHaveBeenCalled()
   })
@@ -118,10 +119,10 @@ describe('setupCaptchaEventListeners', () => {
     })
     mockCaptchaElement.dispatchEvent(event)
 
-    expect(frcChecking.style.display).toBe('none')
-    expect(frcComplete.style.display).toBe('none')
-    expect(frcError.style.display).toBe('block')
-    expect(frcErrorSummary.style.display).toBe('block')
+    expect(frcChecking.classList.contains('govuk-!-display-none')).toBeTruthy()
+    expect(frcComplete.classList.contains('govuk-!-display-none')).toBeTruthy()
+    expect(frcError.classList.contains('govuk-!-display-none')).toBeFalsy()
+    expect(frcErrorSummary.classList.contains('govuk-!-display-none')).toBeFalsy()
     expect(submitButton.disabled).toBe(false)
     expect(document.title).toContain('Error: ')
     expect(errorSummaryElement.focus).toHaveBeenCalled()
@@ -326,10 +327,10 @@ describe('onLoad', () => {
   test('should initialize both captcha listeners and retry button when both elements exist', () => {
     // Setup complete DOM
     document.body.innerHTML = `
-      <div id="FriendlyCaptchaChecking" style="display: block;"></div>
-      <div id="FriendlyCaptchaComplete" style="display: none;"></div>
-      <div id="FriendlyCaptchaError" style="display: none;"></div>
-      <div id="FriendlyCaptchaErrorSummary" style="display: none;">
+      <div id="FriendlyCaptchaChecking" id="FriendlyCaptchaChecking" class="" role="status" aria-live="polite" aria-atomic="true"></div>
+      <div id="FriendlyCaptchaComplete" class="govuk-!-display-none" role="status" aria-live="polite" aria-atomic="true"></div>
+      <div id="FriendlyCaptchaError" class="govuk-!-display-none" role="alert" aria-live="assertive" aria-atomic="true" tabindex="-1"></div>
+      <div id="FriendlyCaptchaErrorSummary" class="govuk-!-display-none">
         <div class="govuk-error-summary" tabindex="-1"></div>
       </div>
       <button id="post-code-button" disabled="true"></button>

--- a/server/public/static/js/__tests__/friendly-captcha-handler.spec.js
+++ b/server/public/static/js/__tests__/friendly-captcha-handler.spec.js
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 
-const { setupCaptchaEventListeners, initRetryButton } = require('../friendly-captcha-handler')
+const { setupCaptchaEventListeners, initRetryButton, onLoad } = require('../friendly-captcha-handler')
 
 describe('setupCaptchaEventListeners', () => {
   let mockCaptchaElement
@@ -210,5 +210,150 @@ describe('initRetryButton', () => {
     retryButton.dispatchEvent(event)
 
     expect(preventDefaultSpy).toHaveBeenCalled()
+  })
+})
+
+describe('onLoad', () => {
+  let addEventListenerSpy
+  let captchaElement
+  let retryButton
+
+  beforeEach(() => {
+    // Clear any previous DOM
+    document.body.innerHTML = ''
+
+    // Reset mocks
+    jest.clearAllMocks()
+
+    // Spy on document.addEventListener
+    addEventListenerSpy = jest.spyOn(document, 'addEventListener')
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  test('should add DOMContentLoaded event listener when document is defined', () => {
+    onLoad()
+
+    expect(addEventListenerSpy).toHaveBeenCalledWith('DOMContentLoaded', expect.any(Function))
+  })
+
+  test('should call setupCaptchaEventListeners when captcha element exists on DOMContentLoaded', () => {
+    // Setup DOM with captcha element
+    document.body.innerHTML = `
+      <div id="FriendlyCaptcha"></div>
+      <a role="button" id="FriendlyCaptchaResetButton" href="/postcode#">Retry</a>
+    `
+
+    onLoad()
+
+    // Get the DOMContentLoaded callback
+    const domContentLoadedCallback = addEventListenerSpy.mock.calls.find(
+      call => call[0] === 'DOMContentLoaded'
+    )[1]
+
+    captchaElement = document.getElementById('FriendlyCaptcha')
+    const captchaListenerSpy = jest.spyOn(captchaElement, 'addEventListener')
+
+    // Trigger the DOMContentLoaded callback
+    domContentLoadedCallback()
+
+    // Verify that the captcha element has the event listener attached
+    expect(captchaListenerSpy).toHaveBeenCalledWith('frc:widget.statechange', expect.any(Function))
+  })
+
+  test('should call initRetryButton on DOMContentLoaded', () => {
+    // Setup DOM with retry button
+    document.body.innerHTML = `
+      <a role="button" id="FriendlyCaptchaResetButton" href="/postcode#">Retry</a>
+    `
+
+    onLoad()
+
+    // Get the DOMContentLoaded callback
+    const domContentLoadedCallback = addEventListenerSpy.mock.calls.find(
+      call => call[0] === 'DOMContentLoaded'
+    )[1]
+
+    retryButton = document.getElementById('FriendlyCaptchaResetButton')
+    const retryButtonListenerSpy = jest.spyOn(retryButton, 'addEventListener')
+
+    // Trigger the DOMContentLoaded callback
+    domContentLoadedCallback()
+
+    expect(retryButtonListenerSpy).toHaveBeenCalledWith('click', expect.any(Function))
+  })
+
+  test('should not call setupCaptchaEventListeners when captcha element does not exist', () => {
+    // Setup DOM without captcha element
+    document.body.innerHTML = `
+      <a role="button" id="FriendlyCaptchaResetButton" href="/postcode#">Retry</a>
+    `
+
+    onLoad()
+
+    // Get the DOMContentLoaded callback
+    const domContentLoadedCallback = addEventListenerSpy.mock.calls.find(
+      call => call[0] === 'DOMContentLoaded'
+    )[1]
+
+    // Trigger the DOMContentLoaded callback - should not throw error
+    expect(() => {
+      domContentLoadedCallback()
+    }).not.toThrow()
+
+    // Verify captcha element doesn't exist
+    expect(document.getElementById('FriendlyCaptcha')).toBeNull()
+  })
+
+  test('should handle case when document is undefined', () => {
+    // Save original document
+    const originalDocument = global.document
+
+    // Temporarily set document to undefined
+    delete global.document
+
+    // Should not throw error
+    expect(() => {
+      onLoad()
+    }).not.toThrow()
+
+    // Restore document
+    global.document = originalDocument
+  })
+
+  test('should initialize both captcha listeners and retry button when both elements exist', () => {
+    // Setup complete DOM
+    document.body.innerHTML = `
+      <div id="FriendlyCaptchaChecking" style="display: block;"></div>
+      <div id="FriendlyCaptchaComplete" style="display: none;"></div>
+      <div id="FriendlyCaptchaError" style="display: none;"></div>
+      <div id="FriendlyCaptchaErrorSummary" style="display: none;">
+        <div class="govuk-error-summary" tabindex="-1"></div>
+      </div>
+      <button id="post-code-button" disabled="true"></button>
+      <div id="FriendlyCaptcha" class="frc-captcha"></div>
+      <a role="button" id="FriendlyCaptchaResetButton" href="/postcode#">Retry</a>
+    `
+
+    onLoad()
+
+    // Get the DOMContentLoaded callback
+    const domContentLoadedCallback = addEventListenerSpy.mock.calls.find(
+      call => call[0] === 'DOMContentLoaded'
+    )[1]
+
+    captchaElement = document.getElementById('FriendlyCaptcha')
+    retryButton = document.getElementById('FriendlyCaptchaResetButton')
+
+    const captchaListenerSpy = jest.spyOn(captchaElement, 'addEventListener')
+    const retryButtonListenerSpy = jest.spyOn(retryButton, 'addEventListener')
+
+    // Trigger the DOMContentLoaded callback
+    domContentLoadedCallback()
+
+    expect(captchaListenerSpy).toHaveBeenCalledWith('frc:widget.statechange', expect.any(Function))
+    expect(retryButtonListenerSpy).toHaveBeenCalledWith('click', expect.any(Function))
   })
 })

--- a/server/public/static/js/captcha-refresh.js
+++ b/server/public/static/js/captcha-refresh.js
@@ -9,12 +9,6 @@ window.addEventListener('pageshow', function (event) {
 })
 if (document.documentMode) {
   // Only true in Internet Explorer
-  // Array.prototype.slice.call(document.querySelectorAll(".frc-captcha")).forEach(function (element) {
-  //   var messageElement = document.createElement("p");
-  //   messageElement.innerHTML =
-  //     "The anti-robot check works better and faster in modern browsers such as Edge, Firefox, or Chrome. Please consider updating your browser";
-  //   element.parentNode.insertBefore(messageElement, element.nextSibling);
-  // });
   const ieBrowser = document.getElementById('nc-browser')
   ieBrowser.style.display = 'block'
 }

--- a/server/public/static/js/friendly-captcha-handler.js
+++ b/server/public/static/js/friendly-captcha-handler.js
@@ -36,7 +36,7 @@ function setupCaptchaEventListeners (captchaElement) {
       hide(frcComplete)
       show(frcError)
       if (frcErrorSummary) {
-        frcErrorSummary.style.display = 'block'
+        show(frcErrorSummary)
         if (!document.title.includes('Error: ')) {
           document.title = 'Error: ' + document.title
         }

--- a/server/public/static/js/friendly-captcha-handler.js
+++ b/server/public/static/js/friendly-captcha-handler.js
@@ -25,18 +25,6 @@ function setupCaptchaEventListeners (captchaElement) {
   const frcErrorSummary = document.getElementById('FriendlyCaptchaErrorSummary')
   const submitButton = document.getElementById('post-code-button')
 
-  function hide (element) {
-    if (element) {
-      element.style.display = 'none'
-    }
-  }
-
-  function show (element) {
-    if (element) {
-      element.style.display = 'block'
-    }
-  }
-
   captchaElement.addEventListener('frc:widget.statechange', function (event) {
     const detail = event.detail
     if (detail.state === 'completed') {
@@ -62,6 +50,28 @@ function setupCaptchaEventListeners (captchaElement) {
       submitButton.disabled = true
     }
   })
+}
+
+/**
+ * Hides an element after checking it's assigned
+ *
+ * @param {HTMLElement} element - The element to hide if it's assigned
+ */
+function hide (element) {
+  if (element) {
+    element.style.display = 'none'
+  }
+}
+
+/**
+ * Shows an element after checking that it's assigned
+ *
+ * @param {HTMLElement} element - The element to show if it's assigned
+ */
+function show (element) {
+  if (element) {
+    element.style.display = 'block'
+  }
 }
 
 /**

--- a/server/public/static/js/friendly-captcha-handler.js
+++ b/server/public/static/js/friendly-captcha-handler.js
@@ -59,7 +59,7 @@ function setupCaptchaEventListeners (captchaElement) {
  */
 function hide (element) {
   if (element) {
-    element.style.display = 'none'
+    element.classList.add('govuk-!-display-none')
   }
 }
 
@@ -70,7 +70,7 @@ function hide (element) {
  */
 function show (element) {
   if (element) {
-    element.style.display = 'block'
+    element.classList.remove('govuk-!-display-none')
   }
 }
 

--- a/server/public/static/js/friendly-captcha-handler.js
+++ b/server/public/static/js/friendly-captcha-handler.js
@@ -1,0 +1,94 @@
+/**
+ * FriendlyCaptcha Event Handler
+ * Manages UI state transitions for the FriendlyCaptcha widget
+ */
+
+/**
+ * Configures event listeners for FriendlyCaptcha widget state changes.
+ * Manages UI transitions between checking, complete, and error states.
+ *
+ * When the captcha completes successfully, hides the "checking" state and shows
+ * the "complete" state, then enables the submit button.
+ *
+ * When an error or expiry occurs, hides checking/complete states, shows the error
+ * state with error summary, updates document title with "Error: " prefix, and
+ * focuses the error summary for accessibility.
+ *
+ * For all other states (fetching, unstarted), the submit button remains disabled.
+ *
+ * @param {HTMLElement} captchaElement - The FriendlyCaptcha widget container element
+ */
+function setupCaptchaEventListeners (captchaElement) {
+  const frcChecking = document.getElementById('FriendlyCaptchaChecking')
+  const frcComplete = document.getElementById('FriendlyCaptchaComplete')
+  const frcError = document.getElementById('FriendlyCaptchaError')
+  const frcErrorSummary = document.getElementById('FriendlyCaptchaErrorSummary')
+  const submitButton = document.getElementById('post-code-button')
+
+  captchaElement.addEventListener('frc:widget.statechange', function (event) {
+    const detail = event.detail
+    if (detail.state === 'completed') {
+      if (frcChecking) {
+        frcChecking.style.display = 'none'
+      }
+      if (frcComplete) {
+        frcComplete.style.display = 'block'
+      }
+      submitButton.disabled = false
+    } else if ((detail.state === 'error') || (detail.state === 'expired')) {
+      if (frcChecking) {
+        frcChecking.style.display = 'none'
+      }
+      if (frcComplete) {
+        frcComplete.style.display = 'none'
+      }
+      if (frcError) {
+        frcError.style.display = 'block'
+      }
+      if (frcErrorSummary) {
+        frcErrorSummary.style.display = 'block'
+        if (!document.title.includes('Error: ')) {
+          document.title = 'Error: ' + document.title
+        }
+        const errorSummary = frcErrorSummary.querySelector('.govuk-error-summary')
+        if (errorSummary) {
+          errorSummary.focus()
+        }
+      }
+      submitButton.disabled = false
+    } else {
+      submitButton.disabled = true
+    }
+  })
+}
+
+/**
+ * Initializes the retry button click handler.
+ * When clicked, prevents default link behavior and reloads the page
+ * to reset the FriendlyCaptcha widget.
+ */
+function initRetryButton () {
+  const retryButton = document.getElementById('FriendlyCaptchaResetButton')
+  if (retryButton) {
+    retryButton.addEventListener('click', function (e) {
+      e.preventDefault()
+      window.location.reload()
+    })
+  }
+}
+
+// Initialize on DOM ready
+if (typeof document !== 'undefined') {
+  document.addEventListener('DOMContentLoaded', function () {
+    const captchaElement = document.getElementById('FriendlyCaptcha')
+    if (captchaElement) {
+      setupCaptchaEventListeners(captchaElement)
+    }
+    initRetryButton()
+  })
+}
+
+// Export for testing (UMD pattern)
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = { setupCaptchaEventListeners, initRetryButton }
+}

--- a/server/public/static/js/friendly-captcha-handler.js
+++ b/server/public/static/js/friendly-captcha-handler.js
@@ -25,26 +25,28 @@ function setupCaptchaEventListeners (captchaElement) {
   const frcErrorSummary = document.getElementById('FriendlyCaptchaErrorSummary')
   const submitButton = document.getElementById('post-code-button')
 
+  function hide (element) {
+    if (element) {
+      element.style.display = 'none'
+    }
+  }
+
+  function show (element) {
+    if (element) {
+      element.style.display = 'block'
+    }
+  }
+
   captchaElement.addEventListener('frc:widget.statechange', function (event) {
     const detail = event.detail
     if (detail.state === 'completed') {
-      if (frcChecking) {
-        frcChecking.style.display = 'none'
-      }
-      if (frcComplete) {
-        frcComplete.style.display = 'block'
-      }
+      hide(frcChecking)
+      show(frcComplete)
       submitButton.disabled = false
     } else if ((detail.state === 'error') || (detail.state === 'expired')) {
-      if (frcChecking) {
-        frcChecking.style.display = 'none'
-      }
-      if (frcComplete) {
-        frcComplete.style.display = 'none'
-      }
-      if (frcError) {
-        frcError.style.display = 'block'
-      }
+      hide(frcChecking)
+      hide(frcComplete)
+      show(frcError)
       if (frcErrorSummary) {
         frcErrorSummary.style.display = 'block'
         if (!document.title.includes('Error: ')) {

--- a/server/public/static/js/friendly-captcha-handler.js
+++ b/server/public/static/js/friendly-captcha-handler.js
@@ -89,18 +89,22 @@ function initRetryButton () {
   }
 }
 
+function onLoad () {
 // Initialize on DOM ready
-if (typeof document !== 'undefined') {
-  document.addEventListener('DOMContentLoaded', function () {
-    const captchaElement = document.getElementById('FriendlyCaptcha')
-    if (captchaElement) {
-      setupCaptchaEventListeners(captchaElement)
-    }
-    initRetryButton()
-  })
+  if (typeof document !== 'undefined') {
+    document.addEventListener('DOMContentLoaded', function () {
+      const captchaElement = document.getElementById('FriendlyCaptcha')
+      if (captchaElement) {
+        setupCaptchaEventListeners(captchaElement)
+      }
+      initRetryButton()
+    })
+  }
 }
+
+onLoad()
 
 // Export for testing (UMD pattern)
 if (typeof module !== 'undefined' && module.exports) {
-  module.exports = { setupCaptchaEventListeners, initRetryButton }
+  module.exports = { setupCaptchaEventListeners, initRetryButton, onLoad }
 }

--- a/server/routes/__tests__/search.spec.js
+++ b/server/routes/__tests__/search.spec.js
@@ -1,6 +1,7 @@
 const STATUS_CODES = require('http2').constants
 const createServer = require('../../../server')
 const floodService = require('../../services/flood')
+const captchaCheck = require('../../services/captchacheck')
 const DEFAULT_POSTCODE = 'CV376YZ'
 const SEARCH_REDIRECT = '/search#'
 const { mockOptions, mockSearchOptions } = require('../../../test/mock')
@@ -10,11 +11,13 @@ jest.mock('../../config')
 jest.mock('../../services/flood')
 jest.mock('../../services/address')
 jest.mock('../../services/risk')
+jest.mock('../../services/captchacheck')
 
 beforeAll(async () => {
   server = await createServer()
   await server.initialize()
   const initial = mockOptions()
+  captchaCheck.captchaCheck.mockResolvedValue({ tokenValid: true })
 
   const homepageresponse = await server.inject(initial)
   expect(homepageresponse.statusCode).toEqual(STATUS_CODES.HTTP_STATUS_OK)
@@ -210,6 +213,26 @@ describe('search page route', () => {
     const postResponse = await server.inject(postOptions)
     expect(postResponse.statusCode).toEqual(STATUS_CODES.HTTP_STATUS_FOUND)
     expect(postResponse.headers.location).toMatch('/england-only?postcode=BT84AA&region=northern-ireland')
+  })
+
+  test('/search - Wales address to redirect to england-only', async () => {
+    const { postOptions } = mockSearchOptions('NP183EZ', cookie)
+    floodService.__updateReturnValue({})
+    const postResponse = await server.inject(postOptions)
+    expect(postResponse.statusCode).toEqual(STATUS_CODES.HTTP_STATUS_FOUND)
+    expect(postResponse.headers.location).toMatch('/england-only?postcode=NP183EZ&region=wales')
+  })
+
+  test('/search - Captcha failure redirects to postcode page', async () => {
+    const { getOptions, postOptions } = mockSearchOptions(DEFAULT_POSTCODE, cookie)
+    floodService.__updateReturnValue({})
+    const postcodeResponse = await server.inject(postOptions)
+    expect(postcodeResponse.statusCode).toEqual(STATUS_CODES.HTTP_STATUS_FOUND)
+    captchaCheck.captchaCheck.mockResolvedValueOnce({ tokenValid: false })
+
+    const getResponse = await server.inject(getOptions)
+    expect(getResponse.statusCode).toEqual(STATUS_CODES.HTTP_STATUS_FOUND)
+    expect(getResponse.headers.location).toMatch('/postcode#')
   })
 
   test('Accept & strip unknown query parameters', async () => {

--- a/server/services/captchacheck.js
+++ b/server/services/captchacheck.js
@@ -101,7 +101,7 @@ async function captchaCheck (token, postcode, yar) {
   const storedToken = yar.get('token')
 
   if (matchesStoredToken(token, storedToken)) {
-    return await validateStoredToken(results, postcode, yar)
+    return validateStoredToken(results, postcode, yar)
   }
 
   if (token) {

--- a/server/views/postcode.html
+++ b/server/views/postcode.html
@@ -19,7 +19,7 @@
         {{ govukErrorSummary(errorSummary) }}
       {% endif %}
       {% if friendlyCaptchaEnabled %}
-      <div id="FriendlyCaptchaErrorSummary" class="do-not-display">
+      <div id="FriendlyCaptchaErrorSummary" class="govuk-!-display-none">
         {{ govukErrorSummary({
           titleText: "There is a problem",
           errorList: [
@@ -45,24 +45,24 @@
         {{ govukInput(postcodeInput) }}
         {% if friendlyCaptchaEnabled %}
 
-          <div style="margin-bottom: 20px; display: none;" id="FriendlyCaptcha" class="govuk-body frc-captcha" data-sitekey={{friendlyCaptchaSiteKey}} data-start="auto"></div>
+          <div id="FriendlyCaptcha" class="govuk-!-display-none frc-captcha" data-sitekey={{friendlyCaptchaSiteKey}} data-start="auto"></div>
           <div id="FriendlyCaptchaChecking" class="" role="status" aria-live="polite" aria-atomic="true">
-              <h3 class="govuk-heading-s">Checking you're not a robot</h3>
+              <h3 class="govuk-heading-s">Checking you are not a robot</h3>
               {{govukTag({
                 text: "Checking...",
                 classes: "govuk-tag--blue"
               })}}
           </div>
-          <div id="FriendlyCaptchaComplete" class="do-not-display" role="status" aria-live="polite" aria-atomic="true">
-              <h3 class="govuk-heading-s">Checking you're not a robot</h3>
+          <div id="FriendlyCaptchaComplete" class="govuk-!-display-none" role="status" aria-live="polite" aria-atomic="true">
+              <h3 class="govuk-heading-s">Checking you are not a robot</h3>
               {{govukTag({
                 text: "Complete",
                 classes: "govuk-tag--green"
               })}}
           </div>
-          <div id="FriendlyCaptchaError" class="do-not-display" role="alert" aria-live="assertive" aria-atomic="true">
+          <div id="FriendlyCaptchaError" class="govuk-!-display-none" role="alert" aria-live="assertive" aria-atomic="true" tabindex="-1">
             <div class="govuk-form-group govuk-form-group--error">
-              <h3 class="govuk-heading-s">Checking you're not a robot</h3>
+              <h3 class="govuk-heading-s">Checking you are not a robot</h3>
               <p class="govuk-error-message">
                 FriendlyCaptcha encountered an error while performing its checks
               </p>
@@ -70,11 +70,11 @@
                   text: "Retry",
                   type: "button",
                   id: "FriendlyCaptchaResetButton",
-                  href: " "
+                  href: "/postcode#"
                 }) }}
             </div>
           </div>
-          <div class="" style="display: none;" id="nc-browser">
+          <div class="govuk-!-display-none" id="nc-browser">
             <p class="govuk-body">The Friendly Captcha check works better and faster in modern browsers such as Edge, Firefox, or Chrome. Please consider updating your browser</p>
           </div>
             <p class="govuk-body govuk-hint govuk-!-margin-top-7">
@@ -182,6 +182,10 @@
 
     document.addEventListener("DOMContentLoaded", function () {
       setupCaptchaEventListeners(document.getElementById('FriendlyCaptcha'))
+      document.getElementById('FriendlyCaptchaResetButton').addEventListener('click', function(e) {
+        e.preventDefault();
+        window.location.reload();
+      });
     })
   </script>
   <script type="module" src="{{ assetPath }}/js/site.min.js" async defer>

--- a/server/views/postcode.html
+++ b/server/views/postcode.html
@@ -45,33 +45,24 @@
         {{ govukInput(postcodeInput) }}
         {% if friendlyCaptchaEnabled %}
 
-          <div style="margin-bottom: 20px; display: none;" id="FriendlyCaptcha" class="govuk-body frc-captcha" data-sitekey={{friendlyCaptchaSiteKey}} data-start="auto" role="status"></div>
-          <div id="FriendlyCaptchaChecking" class="govuk-grid-row">
-            <div class="govuk-grid-column-two-thirds">
-              <p class="govuk-body">
-                Friendly Captcha check
-                {{govukTag({
-          text: "Checking",
-          classes: "govuk-tag--grey"
-        })}}
-              </p>
-            </div>
+          <div style="margin-bottom: 20px; display: none;" id="FriendlyCaptcha" class="govuk-body frc-captcha" data-sitekey={{friendlyCaptchaSiteKey}} data-start="auto"></div>
+          <div id="FriendlyCaptchaChecking" class="">
+              <h3 class="govuk-heading-s">Checking you're not a robot</h3>
+              {{govukTag({
+                text: "Checking...",
+                classes: "govuk-tag--blue"
+              })}}
           </div>
-          <div id="FriendlyCaptchaComplete" class="govuk-grid-row do-not-display">
-            <div class="govuk-grid-column-two-thirds">
-              <p class="govuk-body">
-                Friendly Captcha check
-                {{govukTag({
-          text: "Passed"
-        })}}
-              </p>
-            </div>
+          <div id="FriendlyCaptchaComplete" class="do-not-display">
+              <h3 class="govuk-heading-s">Checking you're not a robot</h3>
+              {{govukTag({
+                text: "Complete",
+                classes: "govuk-tag--green"
+              })}}
           </div>
-          <div id="FriendlyCaptchaError" class="govuk-grid-row do-not-display">
-            <div class="govuk-grid-column-two-thirds govuk-form-group govuk-form-group--error">
-              <p class="govuk-body">
-                Friendly Captcha check
-              </p>
+          <div id="FriendlyCaptchaError" class="do-not-display">
+            <div class="govuk-form-group govuk-form-group--error">
+              <h3 class="govuk-heading-s">Checking you're not a robot</h3>
               <p class="govuk-error-message">
                 FriendlyCaptcha encountered an error while performing its checks
               </p>
@@ -83,22 +74,18 @@
                 }) }}
             </div>
           </div>
-          <div class="govuk-grid-column-two-thirds" style="display: none;" id="nc-browser">
+          <div class="" style="display: none;" id="nc-browser">
             <p class="govuk-body">The Friendly Captcha check works better and faster in modern browsers such as Edge, Firefox, or Chrome. Please consider updating your browser</p>
           </div>
-          <div class="govuk-grid-row">
-            <div class="govuk-grid-column-two-thirds">
-              <p class="govuk-body govuk-hint">
-                Friendly Captcha checks that you aren't a robot. Find out how we use it in our <a href="/privacy-notice" 
-                class="govuk-link">privacy notice</a>
-              </p>
-            </div>
-          </div>
-          <div class="govuk-grid-row">
-            <div class="govuk-grid-column-two-thirds">
-              <button type="submit" id="post-code-button" class="govuk-button">Continue</button>
-            </div>
-          </div>
+            <p class="govuk-body"></p>
+            <p class="govuk-body govuk-hint">
+              Friendly Captcha checks that you aren't a robot.<br>Find out how we use it in our <a href="/privacy-notice" 
+              class="govuk-link">privacy notice</a>
+            </p>
+            <p class="govuk-body govuk-hint">
+              This can take a few seconds. Do not refresh the page.
+            </p>
+            <button type="submit" id="post-code-button" class="govuk-button" disabled="true">Continue</button>
         {% else %}
           <button type="submit" id="post-code-button" class="govuk-button">Continue</button>
         {% endif %}

--- a/server/views/postcode.html
+++ b/server/views/postcode.html
@@ -1,6 +1,8 @@
 {% extends 'layout.html' %}
 
 {% from "components/input/macro.njk" import govukInput %}
+{% from "components/tag/macro.njk" import govukTag %}
+{% from "components/button/macro.njk" import govukButton %}
 {% from "components/error-summary/macro.njk" import govukErrorSummary %}
 
 {% set pageTitle = "Where do you want to check?" %}
@@ -16,6 +18,19 @@
       {% if errorSummary %}
         {{ govukErrorSummary(errorSummary) }}
       {% endif %}
+      {% if friendlyCaptchaEnabled %}
+      <div id="FriendlyCaptchaErrorSummary" class="do-not-display">
+        {{ govukErrorSummary({
+          titleText: "There is a problem",
+          errorList: [
+          {
+            text: "FriendlyCaptcha encountered an error while performing its checks",
+            href: "#FriendlyCaptchaError"
+          }]
+        })}}
+
+      </div>
+      {% endif %}
       <h1 class="govuk-heading-xl">{{ pageTitle }}</h1>
 
       {% if friendlyCaptchaEnabled %}
@@ -29,14 +44,52 @@
       <form id="postcode-form" method="post">
         {{ govukInput(postcodeInput) }}
         {% if friendlyCaptchaEnabled %}
-          <div style="margin-bottom: 20px;" id="FriendlyCaptcha" class="govuk-body frc-captcha" data-sitekey={{friendlyCaptchaSiteKey}} data-start="auto" role="status"></div>
+
+          <div style="margin-bottom: 20px; display: none;" id="FriendlyCaptcha" class="govuk-body frc-captcha" data-sitekey={{friendlyCaptchaSiteKey}} data-start="auto" role="status"></div>
+          <div id="FriendlyCaptchaChecking" class="govuk-grid-row">
+            <div class="govuk-grid-column-two-thirds">
+              <p class="govuk-body">
+                Friendly Captcha check
+                {{govukTag({
+          text: "Checking",
+          classes: "govuk-tag--grey"
+        })}}
+              </p>
+            </div>
+          </div>
+          <div id="FriendlyCaptchaComplete" class="govuk-grid-row do-not-display">
+            <div class="govuk-grid-column-two-thirds">
+              <p class="govuk-body">
+                Friendly Captcha check
+                {{govukTag({
+          text: "Passed"
+        })}}
+              </p>
+            </div>
+          </div>
+          <div id="FriendlyCaptchaError" class="govuk-grid-row do-not-display">
+            <div class="govuk-grid-column-two-thirds govuk-form-group govuk-form-group--error">
+              <p class="govuk-body">
+                Friendly Captcha check
+              </p>
+              <p class="govuk-error-message">
+                FriendlyCaptcha encountered an error while performing its checks
+              </p>
+                {{ govukButton({
+                  text: "Retry",
+                  type: "button",
+                  id: "FriendlyCaptchaResetButton",
+                  href: " "
+                }) }}
+            </div>
+          </div>
           <div class="govuk-grid-column-two-thirds" style="display: none;" id="nc-browser">
-            <p class="govuk-body">The anti-robot check works better and faster in modern browsers such as Edge, Firefox, or Chrome. Please consider updating your browser</p>
+            <p class="govuk-body">The Friendly Captcha check works better and faster in modern browsers such as Edge, Firefox, or Chrome. Please consider updating your browser</p>
           </div>
           <div class="govuk-grid-row">
             <div class="govuk-grid-column-two-thirds">
               <p class="govuk-body govuk-hint">
-                Friendly Captcha checks that you aren't a robot. Find out how to use it in our <a href="/privacy-notice" 
+                Friendly Captcha checks that you aren't a robot. Find out how we use it in our <a href="/privacy-notice" 
                 class="govuk-link">privacy notice</a>
               </p>
             </div>
@@ -97,70 +150,52 @@
 </div>
  </noscript>
  <script>
-    let sessionTimeoutTimer
-
     function setupCaptchaEventListeners(captchaElement) {
-    const submitButton = document.getElementById("post-code-button")
+      const frcChecking = document.getElementById('FriendlyCaptchaChecking')
+      const frcComplete = document.getElementById('FriendlyCaptchaComplete')
+      const frcError = document.getElementById('FriendlyCaptchaError')
+      const frcErrorSummary = document.getElementById('FriendlyCaptchaErrorSummary')
+      const submitButton = document.getElementById('post-code-button')
 
-    captchaElement.addEventListener("frc:widget.statechange", function (event) {
-      const detail = event.detail
+      captchaElement.addEventListener("frc:widget.statechange", function (event) {
+        const detail = event.detail
         if (detail.state === "completed") {
+          if (frcChecking) {
+            frcChecking.style.display = 'none'
+          }
+          if (frcComplete) {
+            frcComplete.style.display = 'block'
+          }
           submitButton.disabled = false
-          captchaDone(detail.response)
-        } else if (detail.state === "error") {
+        } else if ((detail.state === "error") || (detail.state === "expired")) {
+          if (frcChecking) {
+            frcChecking.style.display = 'none'
+          }
+          if (frcComplete) {
+            frcComplete.style.display = 'none'
+          }
+          if (frcError) {
+            frcError.style.display = 'block'
+          }
+          if (frcErrorSummary) {
+            frcErrorSummary.style.display = 'block'
+            if (!document.title.includes('Error: ')) {
+              document.title = 'Error: ' + document.title
+            }
+            const errorSummary = frcErrorSummary.querySelector('.govuk-error-summary')
+            if (errorSummary) {
+              errorSummary.focus()
+            }
+          }
           submitButton.disabled = false
-          captchaError()
         } else {
           submitButton.disabled = true
         }
       })
     }
 
-    function enableTimeout(expiry) {
-      if (sessionTimeoutTimer) {
-        clearTimeout(sessionTimeoutTimer)
-        sessionTimeoutTimer = null
-      }
-      if (expiry > 0) {
-        sessionTimeoutTimer = setTimeout(() => friendlyCaptchaExpire(), expiry);
-      }  
-    }
-    function friendlyCaptchaExpire() {
-      fixupFriendlyCaptcha()
-    }
-    function fixupFriendlyCaptcha() {
-      // Accessibility edits to the FriendlyCaptcha widget.
-      // Stop the Friendly Captcha link opening in a new window and add gov styling.
-      const link = document.querySelector("div.frc-banner > a")
-      if (link) {
-        link.target = ''
-        link.className += ' govuk-link'
-      }
-    }
-    function observeCaptchaRender() {
-      // Work around to apply Friendly Captcha link accessability change when the page is refreshed as this was not applying previously.
-      const observer = new MutationObserver(() => {
-        const captchaLink = document.querySelector("div.frc-banner > a")
-        if (captchaLink) {
-          fixupFriendlyCaptcha()
-          observer.disconnect()
-        }
-      })
-      observer.observe(document.body, {
-        childList: true,
-        subtree: true
-      })
-    }
-    
-    function captchaDone(solutionPayload) {
-      fixupFriendlyCaptcha()
-    }
-    function captchaError() {
-      enableTimeout(0)
-    }
     document.addEventListener("DOMContentLoaded", function () {
-      fixupFriendlyCaptcha()
-      observeCaptchaRender()
+      setupCaptchaEventListeners(document.getElementById('FriendlyCaptcha'))
     })
   </script>
   <script type="module" src="{{ assetPath }}/js/site.min.js" async defer>

--- a/server/views/postcode.html
+++ b/server/views/postcode.html
@@ -46,21 +46,21 @@
         {% if friendlyCaptchaEnabled %}
 
           <div style="margin-bottom: 20px; display: none;" id="FriendlyCaptcha" class="govuk-body frc-captcha" data-sitekey={{friendlyCaptchaSiteKey}} data-start="auto"></div>
-          <div id="FriendlyCaptchaChecking" class="">
+          <div id="FriendlyCaptchaChecking" class="" role="status" aria-live="polite" aria-atomic="true">
               <h3 class="govuk-heading-s">Checking you're not a robot</h3>
               {{govukTag({
                 text: "Checking...",
                 classes: "govuk-tag--blue"
               })}}
           </div>
-          <div id="FriendlyCaptchaComplete" class="do-not-display">
+          <div id="FriendlyCaptchaComplete" class="do-not-display" role="status" aria-live="polite" aria-atomic="true">
               <h3 class="govuk-heading-s">Checking you're not a robot</h3>
               {{govukTag({
                 text: "Complete",
                 classes: "govuk-tag--green"
               })}}
           </div>
-          <div id="FriendlyCaptchaError" class="do-not-display">
+          <div id="FriendlyCaptchaError" class="do-not-display" role="alert" aria-live="assertive" aria-atomic="true">
             <div class="govuk-form-group govuk-form-group--error">
               <h3 class="govuk-heading-s">Checking you're not a robot</h3>
               <p class="govuk-error-message">
@@ -77,12 +77,11 @@
           <div class="" style="display: none;" id="nc-browser">
             <p class="govuk-body">The Friendly Captcha check works better and faster in modern browsers such as Edge, Firefox, or Chrome. Please consider updating your browser</p>
           </div>
-            <p class="govuk-body"></p>
-            <p class="govuk-body govuk-hint">
+            <p class="govuk-body govuk-hint govuk-!-margin-top-7">
               Friendly Captcha checks that you aren't a robot.<br>Find out how we use it in our <a href="/privacy-notice" 
               class="govuk-link">privacy notice</a>
             </p>
-            <p class="govuk-body govuk-hint">
+            <p class="govuk-body govuk-hint govuk-!-margin-bottom-5">
               This can take a few seconds. Do not refresh the page.
             </p>
             <button type="submit" id="post-code-button" class="govuk-button" disabled="true">Continue</button>

--- a/server/views/postcode.html
+++ b/server/views/postcode.html
@@ -135,63 +135,11 @@
   </div>
 </div>
  </noscript>
- <script>
-    function setupCaptchaEventListeners(captchaElement) {
-      const frcChecking = document.getElementById('FriendlyCaptchaChecking')
-      const frcComplete = document.getElementById('FriendlyCaptchaComplete')
-      const frcError = document.getElementById('FriendlyCaptchaError')
-      const frcErrorSummary = document.getElementById('FriendlyCaptchaErrorSummary')
-      const submitButton = document.getElementById('post-code-button')
-
-      captchaElement.addEventListener("frc:widget.statechange", function (event) {
-        const detail = event.detail
-        if (detail.state === "completed") {
-          if (frcChecking) {
-            frcChecking.style.display = 'none'
-          }
-          if (frcComplete) {
-            frcComplete.style.display = 'block'
-          }
-          submitButton.disabled = false
-        } else if ((detail.state === "error") || (detail.state === "expired")) {
-          if (frcChecking) {
-            frcChecking.style.display = 'none'
-          }
-          if (frcComplete) {
-            frcComplete.style.display = 'none'
-          }
-          if (frcError) {
-            frcError.style.display = 'block'
-          }
-          if (frcErrorSummary) {
-            frcErrorSummary.style.display = 'block'
-            if (!document.title.includes('Error: ')) {
-              document.title = 'Error: ' + document.title
-            }
-            const errorSummary = frcErrorSummary.querySelector('.govuk-error-summary')
-            if (errorSummary) {
-              errorSummary.focus()
-            }
-          }
-          submitButton.disabled = false
-        } else {
-          submitButton.disabled = true
-        }
-      })
-    }
-
-    document.addEventListener("DOMContentLoaded", function () {
-      setupCaptchaEventListeners(document.getElementById('FriendlyCaptcha'))
-      document.getElementById('FriendlyCaptchaResetButton').addEventListener('click', function(e) {
-        e.preventDefault();
-        window.location.reload();
-      });
-    })
-  </script>
   <script type="module" src="{{ assetPath }}/js/site.min.js" async defer>
   </script>
   <script nomodule src="{{ assetPath }}/js/site.compat.min.js" async defer>
   </script>
+  <script src="{{ assetPath }}/js/friendly-captcha-handler.js"></script>
   <script src="{{ assetPath }}/js/captcha-refresh.js"></script>
 {% endif %}
 {% endblock %}


### PR DESCRIPTION
This change alters the way the FriendlyCaptcha widget is displayed. It hides the third party widget and uses events from that widget to display gov.uk styled messages instead.

Update the FriendlyCaptcha module to keep it up to date with the latest security and bug fixes.
Remove the timeout handling code, and this is no longer needed. On timeout if the form is submitted an error will be displayed there. Removing this reduces complexity without impacting user experience.
