### PR TITLE
Header fix - Update cyltfr-app to gov.uk framework V6

### DIFF
--- a/server/views/layout.html
+++ b/server/views/layout.html
@@ -64,12 +64,14 @@ window.loadAnalytics = () => {
     height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
     <!-- End Google Tag Manager (noscript) -->
   {% endif %}
-  {% block govukHeader %}
-    {{ govukHeader({
-      homepageUrl: "https://www.gov.uk",
-      containerClasses: "govuk-width-container"
-    }) }}
-  {% endblock %}
+  <header>
+    {% block govukHeader %}
+      {{ govukHeader({
+        homepageUrl: "https://www.gov.uk",
+        containerClasses: "govuk-width-container"
+      }) }}
+    {% endblock %}
+  </header>
 
   {{ govukServiceNavigation({
     serviceName: serviceName,

--- a/server/views/partials/unsupported.html
+++ b/server/views/partials/unsupported.html
@@ -15,12 +15,14 @@
   height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <!-- End Google Tag Manager (noscript) -->
 {% endif %}
-  {% block govukHeader %}
-    {{ govukHeader({
-      homepageUrl: "https://www.gov.uk",
-      containerClasses: "govuk-width-container"
-    }) }}
-  {% endblock %}
+  <header>
+    {% block govukHeader %}
+      {{ govukHeader({
+        homepageUrl: "https://www.gov.uk",
+        containerClasses: "govuk-width-container"
+      }) }}
+    {% endblock %}
+  </header>
 
   {{ govukServiceNavigation({
     serviceName: serviceName,


### PR DESCRIPTION

https://eaflood.atlassian.net/browse/LTFRI-2333

This fix will add the header back to layout.html.