### PR TITLE
GOV.UK frontend v6.3.0

### DIFF
--- a/client/sass/_border-utils.scss
+++ b/client/sass/_border-utils.scss
@@ -1,4 +1,4 @@
-@use 'govuk-frontend/dist/govuk/settings/colours-palette' as *;
+@use 'govuk-frontend/dist/govuk/settings/index' as *;
 @use 'govuk-frontend/dist/govuk/helpers/index' as *;
 
 $border-width-scale: (

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "@hapi/yar": "^11.0.3",
         "blipp": "4.0.2",
         "dotenv": "^17.4.1",
-        "govuk-frontend": "^6.1.0",
+        "govuk-frontend": "^6.3.0",
         "hapi-pino": "^13.0.0",
         "hapi-rate-limit": "^8.0.0",
         "https-proxy-agent": "^7.0.6",
@@ -7651,9 +7651,9 @@
       }
     },
     "node_modules/govuk-frontend": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-6.1.0.tgz",
-      "integrity": "sha512-sqivexZFa82LiDIDVMItsUlqEXE/wEUWWBqzEoxHvUFLBH7bY0C8lVrj1qsDThSnj5JEUMS7isBAbKnfQ5Qp6g==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-6.3.0.tgz",
+      "integrity": "sha512-cXIQxm5PHCsbic47GXZrVBZhAeeshTLRL6ZBKilLsR6rMCjJuWb7Fruq0VUNMBJFlJk/srsRj/q8d5bM9cgKoA==",
       "license": "MIT",
       "engines": {
         "node": ">= 4.2.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1763,9 +1763,9 @@
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@hapi/yar": "^11.0.3",
     "blipp": "4.0.2",
     "dotenv": "^17.4.1",
-    "govuk-frontend": "^6.1.0",
+    "govuk-frontend": "^6.3.0",
     "hapi-pino": "^13.0.0",
     "hapi-rate-limit": "^8.0.0",
     "https-proxy-agent": "^7.0.6",


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/LTFRI-2525

This will update the service to use the newest version of gov.uk frontend.