### PR TITLE
Fix issue with Feedback page title

### DIFF
--- a/server/views/feedback.html
+++ b/server/views/feedback.html
@@ -2,8 +2,6 @@
 
 {% from "components/back-link/macro.njk" import govukBackLink %}
 
-{% set pageTitle = "There was a problem displaying the feedback form" %}
-
 {% block containerStart %}
 <div class="top-page-links">
   {{ govukBackLink({
@@ -21,7 +19,7 @@
   <div class="feedback">
     <script id="ss-embed-1299763">(function(d,w){var s,ss;ss=d.createElement('script');ss.type='text/javascript';ss.async=true;ss.src=('https:'==d.location.protocol?'https://':'http://')+'www.smartsurvey.co.uk/s/r/embed.aspx?i=986952&c=1299763&ref={{ref}}&useragent={{userAgent}}';s=d.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ss, s);})(document,window);</script>
     <div class="noscript-iframe text">
-      <h1 class="govuk-heading-xl">{{ pageTitle }}</h1>
+      <h1 class="govuk-heading-xl">There was a problem displaying the feedback form</h1>
       <p>We can&#39;t display the feedback form. This is usually because JavaScript is turned off in your browser (for example Chrome, Explorer, Firefox or Safari).</p>
       <p>Turn JavaScript on in your &#39;Preferences&#39; menu if you would like to try again.</p>
       <p>Alternatively <a href="https://www.gov.uk/government/organisations/environment-agency#org-contacts">you can contact us</a></p>


### PR DESCRIPTION
The feedback title was set incorrectly in a previous change. Sorting that out here.