### PR TITLE
Cookie name fix - Update contents of cookies page

### DIFF
--- a/server/views/cookies.html
+++ b/server/views/cookies.html
@@ -72,7 +72,7 @@
               { text: "7 days" }
             ],
             [
-              { text: "AWSALBTHCORS" },
+              { text: "AWSALBTGCORS" },
               { text: "Helps the website work properly when connecting to related online services" },
               { text: "7 days" }
             ]


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/LTFRI-2563

This update corrects the AWS cookie name.